### PR TITLE
D1 draft incorporating LWG feedback

### DIFF
--- a/d1518-container-deduction-guides.bs
+++ b/d1518-container-deduction-guides.bs
@@ -172,10 +172,19 @@ looking at the implicit guide generated from the constructor
 
 From the first parameter, we deduce `T=int` and `Allocator=std::pmr::polymorphic_allocator<int>`.
 From the second parameter, we deduce `Allocator=std::monotonic_buffer_resource*`.
-We've deduced conflicting types for `Allocator`, so deduction fails.
+We've deduced conflicting types for `Allocator`, so deduction fails. 
 
 In this case, the second argument unnecessarily participates in deduction, and again unexpectedly
 prevents natural and useful code from working as desired.
+
+To see  that 
+the allocator argument is irrelevant to deduction, note that a vector can only be 
+constructed from a vector of the same type. E.g.,
+```c++
+std::vector<int, std::pmr::polymorphic_allocator<int>> pv2(pv, &mr); // OK. Same types
+std::vector<int> v(pv, std::allocator<int>());  // Ill-formed. No such constructor
+```
+
 
 
 ## The solution ## {#solution2}
@@ -480,4 +489,5 @@ implementation of this proposal, as an alternative to directly implementing the 
     "date": "June 2017"
   }
 }
+
 </pre>

--- a/d1518-container-deduction-guides.bs
+++ b/d1518-container-deduction-guides.bs
@@ -1,22 +1,22 @@
 <pre class='metadata'>
 Title: Stop overconstraining allocators in container deduction guides
 Shortname: D1518
-Revision: 0
-!Draft Revision: 4
-Audience: LEWG
+Revision: 1
+!Draft Revision: 0
+Audience: LWG
 Status: D
 Group: WG21
 URL:
 !Current Source: <a href="https://github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs">github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs</a>
-!Current: <a href="https://rawgit.com/Quuxplusone/draft/gh-pages/stack-ctad.html">rawgit.com/Quuxplusone/draft/gh-pages/stack-ctad.html</a>
+!Current: <a href="https://rawgit.com/Quuxplusone/draft/gh-pages/d1518-container-deduction-guides.html">https://rawgit.com/Quuxplusone/draft/gh-pages/d1518-container-deduction-guides.html</a>
 Editor: Arthur O'Dwyer, arthur.j.odwyer@gmail.com
-Editor: Mike Spertus, mike_spertus@symantec.com
+Editor: Mike Spertus, msspertu@amazon.com
 Markup Shorthands: markdown yes, biblio yes, markup yes
 Abstract:
   Discussion of flatmap’s deduction guides revealed that the deduction guides for sequence
   containers and container adaptors are needlessly overconstrained, making use cases such as
   pmr containers unnecessarily difficult. We fix this.
-Date: 2019-03-09
+Date: 2021-02-13
 </pre>
 
 <style>
@@ -24,6 +24,9 @@ ins  {background-color: #CCFFCC; text-decoration: underline;}
 del  {background-color: #FFCACA; text-decoration: line-through;}
 </style>
 
+# Changelog # {#changelog}
+
+- R1: Incorporate LWG feedback on wording in [[#overconst1]] and to adopt Wording Option 1 in [[#overconst2]]
 
 # Stop overconstraining allocators that do not participate in deduction # {#overconst1}
 
@@ -108,8 +111,8 @@ A deduction guide for a container adaptor shall not participate in overload reso
 - It has a `Container` template parameter and a type that qualifies as an allocator is deduced
      for that parameter.
 
-- <del>It has an `Allocator` template parameter and a type that does not qualify as an allocator
-     is deduced for that parameter.</del>
+- It has <ins>no Container template parameter, and it has</ins> an `Allocator` template parameter<ins>,</ins> and a type that does not qualify as an allocator
+     is deduced for that parameter.
 
 - It has both `Container` and `Allocator` template parameters, and
      `uses_allocator_v<Container, Allocator>` is `false`.
@@ -177,13 +180,11 @@ prevents natural and useful code from working as desired.
 
 ## The solution ## {#solution2}
 
-We present two approaches for changing the wording that are equivalent in effect.
-
-### Wording option 1 ### {#option1}
 
 If we were introducing the containers from scratch today, the natural approach would be for the
 constructors to indicate which arguments should be considered deducible, as is usual for function templates.
-For example, modify [ [deque.overview](http://eel.is/c++draft/deque.overview)] as follows:
+
+Modify [ [deque.overview](http://eel.is/c++draft/deque.overview)] as follows:
 
 <small><blockquote>
 <pre>
@@ -200,163 +201,202 @@ For example, modify [ [deque.overview](http://eel.is/c++draft/deque.overview)] a
 changed, because its `Allocator` parameter actually does contribute to deduction: without
 that parameter's type, we would not know what the `deque`'s allocator type should be.)
 
-If this is not deemed to cause compatibility issues, we like this approach.
 
-
-### Wording option 2 ### {#option2}
-
-First modify
-[ [sequence.reqmts](http://eel.is/c++draft/sequence.reqmts#13)]/13 as follows:
-
-<small><blockquote>
-A deduction guide for a sequence container shall not participate in overload resolution
-if it has an `InputIterator` template parameter and a type that does not qualify as an
-input iterator is deduced for that parameter, or if it has an `Allocator` template parameter
-and a type that does not qualify as an allocator is deduced for that parameter<ins>,
-or if it has an `Alloc` template parameter and `uses_allocator_v<X, Alloc>` is `false`
-where `X` is the deduced type of the sequence container</ins>.
-</blockquote></small>
-
-(We think that change is not strictly necessary, but it clarifies our intent.)
-
-Add one new deduction guide for each sequence container. For example, modify
-[ [deque.overview](http://eel.is/c++draft/deque.overview)] as follows:
+Modify [ [forwardlist.overview](http://eel.is/c++draft/forwardlist.overview)] as follows:
 
 <small><blockquote>
 <pre>
-    template&lt;class InputIterator, class Allocator = allocator&lt;<i>iter-value-type</i>&lt;InputIterator>>>
-        deque(InputIterator, InputIterator, Allocator = Allocator())
-          -> deque&lt;<i>iter-value-type</i>&lt;InputIterator>, Allocator>;
-
-    <ins>template&lt;class T, class Allocator, class Alloc>
-        deque(deque&lt;T, Allocator>, Alloc)
-          -> deque&lt;T, Allocator>;</ins>
+    forward_list(forward_list&&);
+    <del>forward_list(const forward_list&, const Allocator&);</del>
+    <ins>forward_list(const forward_list&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>forward_list(forward_list&&, const Allocator&);</del>
+    <ins>forward_list(forward_list&&, const type_identity_t&lt;Allocator>&);</ins>
+    forward_list(initializer_list&lt;T>, const Allocator& = Allocator());
 </pre>
 </blockquote></small>
 
-Then, modify [ [associative.reqmts](http://eel.is/c++draft/associative.reqmts#15)]/15 as follows:
-
-<small><blockquote>
-A deduction guide for an associative container shall not participate in overload resolution
-if any of the following are true:
-
-- It has an `InputIterator` template parameter and a type that does not qualify as an input iterator
-        is deduced for that parameter.
-
-- It has an `Allocator` template parameter and a type that does not qualify as an allocator
-        is deduced for that parameter.
-
-- It has a `Compare` template parameter and a type that qualifies as an allocator is
-        deduced for that parameter.
-
-- <ins>It has an `Alloc` template parameter and `uses_allocator_v<X, Alloc>` is `false`
-        where `X` is the deduced type of the associative container</ins>.
-
-</blockquote></small>
-
-(We think that change is not strictly necessary, but it clarifies our intent.)
-
-Add one new deduction guide for each associative container. For example, modify
-[ [set.overview](http://eel.is/c++draft/set.overview)] as follows:
+Modify [ [list.overview](http://eel.is/c++draft/list.overview)] as follows:
 
 <small><blockquote>
 <pre>
-    template&lt;class InputIterator,
-             class Compare = less&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-             class Allocator = allocator&lt;<i>iter-value-type</i>&lt;InputIterator>>>
-      set(InputIterator, InputIterator,
-          Compare = Compare(), Allocator = Allocator())
-        -> set&lt;<i>iter-value-type</i>&lt;InputIterator>, Compare, Allocator>;
-
-    template&lt;class Key, class Compare = less&lt;Key>, class Allocator = allocator&lt;Key>>
-      set(initializer_list&lt;Key>, Compare = Compare(), Allocator = Allocator())
-        -> set&lt;Key, Compare, Allocator>;
-
-    template&lt;class InputIterator, class Allocator>
-      set(InputIterator, InputIterator, Allocator)
-        -> set&lt;<i>iter-value-type</i>&lt;InputIterator>,
-               less&lt;<i>iter-value-type</i>&lt;InputIterator>>, Allocator>;
-
-    template&lt;class Key, class Allocator>
-      set(initializer_list&lt;Key>, Allocator) -> set&lt;Key, less&lt;Key>, Allocator>;
-
-    <ins>template&lt;class Key, class Compare, class Allocator, class Alloc>
-      set(set&lt;Key, Compare, Allocator>, Alloc) -> set&lt;Key, Compare, Allocator>;</ins>
+    list(list&&);
+    <del>list(const list&, const Allocator&);</del>
+    <ins>list(const list&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>list(list&&, const Allocator&);</del>
+    <ins>list(list&&, const type_identity_t&lt;Allocator>&);</ins>
+    list(initializer_list&lt;T>, const Allocator& = Allocator());
 </pre>
 </blockquote></small>
 
-Then, modify [ [unord.req](http://eel.is/c++draft/unord.req#18)]/18 as follows:
-
-<small><blockquote>
-A deduction guide for an unordered associative container shall not participate in overload resolution
-if any of the following are true:
-
-- It has an `InputIterator` template parameter and a type that does not qualify as an input iterator
-        is deduced for that parameter.
-
-- It has an `Allocator` template parameter and a type that does not qualify as an allocator
-        is deduced for that parameter.
-
-- It has a `Hash` template parameter and an integral type or a type that qualifies as an allocator
-        is deduced for that parameter.
-
-- It has a `Pred` template parameter and a type that qualifies as an allocator is
-        deduced for that parameter.
-
-- <ins>It has an `Alloc` template parameter and `uses_allocator_v<X, Alloc>` is `false`
-        where `X` is the deduced type of the associative container</ins>.
-
-</blockquote></small>
-
-(We think that change is not strictly necessary, but it clarifies our intent.)
-
-Add one new deduction guide for each unordered associative container. For example, modify
-[ [unord.set.overview](http://eel.is/c++draft/unord.set.overview)] as follows:
+Modify [ [vector.overview](http://eel.is/c++draft/vector.overview)] as follows:
 
 <small><blockquote>
 <pre>
-    template&lt;class InputIterator,
-             class Hash = hash&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-             class Pred = equal_to&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-             class Allocator = allocator&lt;<i>iter-value-type</i>&lt;InputIterator>>>
-      unordered_set(InputIterator, InputIterator, typename <i>see below</i>::size_type = <i>see below</i>,
-                    Hash = Hash(), Pred = Pred(), Allocator = Allocator())
-        -> unordered_set&lt;<i>iter-value-type</i>&lt;InputIterator>,
-                         Hash, Pred, Allocator>;
-
-    template&lt;class T, class Hash = hash&lt;T>,
-             class Pred = equal_to&lt;T>, class Allocator = allocator&lt;T>>
-      unordered_set(initializer_list&lt;T>, typename <i>see below</i>::size_type = <i>see below</i>,
-                    Hash = Hash(), Pred = Pred(), Allocator = Allocator())
-        -> unordered_set&lt;T, Hash, Pred, Allocator>;
-
-    template&lt;class InputIterator, class Allocator>
-      unordered_set(InputIterator, InputIterator, typename <i>see below</i>::size_type, Allocator)
-        -> unordered_set&lt;<i>iter-value-type</i>&lt;InputIterator>,
-                         hash&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-                         equal_to&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-                         Allocator>;
-
-    template&lt;class InputIterator, class Hash, class Allocator>
-      unordered_set(InputIterator, InputIterator, typename <i>see below</i>::size_type,
-                    Hash, Allocator)
-        -> unordered_set&lt;<i>iter-value-type</i>&lt;InputIterator>, Hash,
-                         equal_to&lt;<i>iter-value-type</i>&lt;InputIterator>>,
-                         Allocator>;
-
-    template&lt;class T, class Allocator>
-      unordered_set(initializer_list&lt;T>, typename <i>see below</i>::size_type, Allocator)
-        -> unordered_set&lt;T, hash&lt;T>, equal_to&lt;T>, Allocator>;
-
-    template&lt;class T, class Hash, class Allocator>
-      unordered_set(initializer_list&lt;T>, typename <i>see below</i>::size_type, Hash, Allocator)
-        -> unordered_set&lt;T, Hash, equal_to&lt;T>, Allocator>;
-
-    <ins>template&lt;class T, class Hash, class Pred, class Allocator, class Alloc>
-      unordered_set(set&lt;T, Hash, Pred, Allocator>, Alloc)
-        -> unordered_set&lt;T, Hash, Pred, Allocator>;</ins>
+    constexpr vector(vector&&) noexcept;
+    <del>constexpr vector(const vector&, const Allocator&);</del>
+    <ins>constexpr vector(const vector&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>constexpr vector(vector&&, const Allocator&);</del>
+    <ins>constexpr vector(vector&&, const type_identity_t&lt;Allocator>&);</ins>
+    constexpr vector(initializer_list&lt;T>, const Allocator& = Allocator());
 </pre>
 </blockquote></small>
+
+Modify [ [vector.bool](http://eel.is/c++draft/vector.bool)] as follows:
+
+<small><blockquote>
+<pre>
+    constexpr vector(vector&&) noexcept;
+    <del>constexpr vector(const vector&, const Allocator&);</del>
+    <ins>constexpr vector(const vector&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>constexpr vector(vector&&, const Allocator&);</del>
+    <ins>constexpr vector(vector&&, const type_identity_t&lt;Allocator>&);</ins>
+    constexpr vector(initializer_list&lt;T>, const Allocator& = Allocator());
+</pre>
+</blockquote></small>
+
+Modify [ [map.overview](http://eel.is/c++draft/map.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit map(const Allocator&);
+    <del>map(const map&, const Allocator&);</del>
+    <ins>map(const map&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>map(map&&, const Allocator&);</del>
+    <ins>map(map&&, const type_identity_t&lt;Allocator>&);</ins>
+    map(initializer_list&lt;value_type>,
+      const Compare& = Compare,
+      const Allocator& = Allocator());
+</pre>
+</blockquote></small>
+
+Modify [ [multimap.overview](http://eel.is/c++draft/multimap.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit multimap(const Allocator&);
+    <del>multimap(const multimap&, const Allocator&);</del>
+    <ins>multimap(const multimap&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>multimap(multimap&&, const Allocator&);</del>
+    <ins>multimap(multimap&&, const type_identity_t&lt;Allocator>&);</ins>
+    multimap(initializer_list&lt;value_type>, 
+      const Compare& = Compare,
+      const Allocator& = Allocator());
+</pre>
+</blockquote></small>
+
+Modify [ [set.overview](http://eel.is/c++draft/set.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit set(const Allocator&);
+    <del>set(const set&, const Allocator&);</del>
+    <ins>set(const set&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>set(set&&, const Allocator&);</del>
+    <ins>set(set&&, const type_identity_t&lt;Allocator>&);</ins>
+    set(initializer_list&lt;T>, const Compare& = Compare(), Allocator,
+        const Allocator& = Allocator());
+</pre>
+</blockquote></small>
+
+Modify [ [multiset.overview](http://eel.is/c++draft/multiset.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit multiset(const Allocator&);
+    <del>multiset(const multiset&, const Allocator&);</del>
+    <ins>multiset(const multiset&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>multiset(multiset&&, const Allocator&);</del>
+    <ins>multiset(multiset&&, const type_identity_t&lt;Allocator>&);</ins>
+    multiset(initializer_list&lt;T>, const Compare& = Compare(), Allocator,
+        const Allocator& = Allocator());
+</pre>
+</blockquote></small>
+
+Modify [ [unord.map.overview](http://eel.is/c++draft/unord.map.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit unordered_map(const Allocator&);
+    <del>unordered_map(const unordered_map&, const Allocator&);</del>
+    <ins>unordered_map(const unordered_map&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>unordered_map(unordered_map&&, const Allocator&);</del>
+    <ins>unordered_map(unordered_map&&, const type_identity_t&lt;Allocator>&);</ins>
+    unordered_map(initializer_list&lt;value_type>,
+                  size_type n = <i>see below</i>,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+</pre>
+</blockquote></small>
+
+Modify [ [unord.multimap.overview](http://eel.is/c++draft/unord.multimap.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit unordered_multimap(const Allocator&);
+    <del>unordered_multimap(const unordered_multimap&, const Allocator&);</del>
+    <ins>unordered_multimap(const unordered_multimap&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>unordered_multimap(unordered_multimap&&, const Allocator&);</del>
+    <ins>unordered_multimap(unordered_multimap&&, const type_identity_t&lt;Allocator>&);</ins>
+    unordered_multimap(initializer_list&lt;value_type>,
+                  size_type n = <i>see below</i>,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+</pre>
+</blockquote></small>
+
+Modify [ [unord.multimap.overview](http://eel.is/c++draft/unord.multimap.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit unordered_multimap(const Allocator&);
+    <del>unordered_multimap(const unordered_multimap&, const Allocator&);</del>
+    <ins>unordered_multimap(const unordered_multimap&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>unordered_multimap(unordered_multimap&&, const Allocator&);</del>
+    <ins>unordered_multimap(unordered_multimap&&, const type_identity_t&lt;Allocator>&);</ins>
+    unordered_multimap(initializer_list&lt;value_type>,
+                  size_type n = <i>see below</i>,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+</pre>
+</blockquote></small>
+
+Modify [ [unord.set.overview](http://eel.is/c++draft/unord.set.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit unordered_set(const Allocator&);
+    <del>unordered_set(const unordered_set&, const Allocator&);</del>
+    <ins>unordered_set(const unordered_set&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>unordered_set(unordered_set&&, const Allocator&);</del>
+    <ins>unordered_set(unordered_set&&, const type_identity_t&lt;Allocator>&);</ins>
+    unordered_set(initializer_list&lt;value_type>,
+                  size_type n = <i>see below</i>,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+</pre>
+</blockquote></small>
+
+Modify [ [unord.multiset.overview](http://eel.is/c++draft/unord.multiset.overview)] as follows:
+
+<small><blockquote>
+<pre>
+    explicit unordered_multiset(const Allocator&);
+    <del>unordered_multiset(const unordered_multiset&, const Allocator&);</del>
+    <ins>unordered_multiset(const unordered_multiset&, const type_identity_t&lt;Allocator>&);</ins>
+    <del>unordered_multiset(unordered_multiset&&, const Allocator&);</del>
+    <ins>unordered_multiset(unordered_multiset&&, const type_identity_t&lt;Allocator>&);</ins>
+    unordered_multiset(initializer_list&lt;value_type>,
+                  size_type n = <i>see below</i>,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+</pre>
+</blockquote></small>
+
 
 ## Implementation note ## {#implementation}
 While implementers may of course implement this proposal exactly as described in the wording options above,
@@ -391,7 +431,7 @@ proposing here as shown in the following table and [this Godbolt](https://godbol
 </small>
 
 The following analysis explains why MSVC, in effect, already implements
-the approach described in [wording option 1](#option1) above.
+the approach described in [[#solution2]] above.
 Consider the implicit guide generated from the constructor
 
 ```c++

--- a/d1518-container-deduction-guides.bs
+++ b/d1518-container-deduction-guides.bs
@@ -355,23 +355,6 @@ Modify [ [unord.multimap.overview](http://eel.is/c++draft/unord.multimap.overvie
 </pre>
 </blockquote></small>
 
-Modify [ [unord.multimap.overview](http://eel.is/c++draft/unord.multimap.overview)] as follows:
-
-<small><blockquote>
-<pre>
-    explicit unordered_multimap(const Allocator&);
-    <del>unordered_multimap(const unordered_multimap&, const Allocator&);</del>
-    <ins>unordered_multimap(const unordered_multimap&, const type_identity_t&lt;Allocator>&);</ins>
-    <del>unordered_multimap(unordered_multimap&&, const Allocator&);</del>
-    <ins>unordered_multimap(unordered_multimap&&, const type_identity_t&lt;Allocator>&);</ins>
-    unordered_multimap(initializer_list&lt;value_type>,
-                  size_type n = <i>see below</i>,
-                  const hasher& hf = hasher(),
-                  const key_equal& eql = key_equal(),
-                  const allocator_type& a = allocator_type());
-</pre>
-</blockquote></small>
-
 Modify [ [unord.set.overview](http://eel.is/c++draft/unord.set.overview)] as follows:
 
 <small><blockquote>

--- a/d1518-container-deduction-guides.html
+++ b/d1518-container-deduction-guides.html
@@ -2373,22 +2373,6 @@ that parameter’s type, we would not know what the <code class="highlight"><c- 
               <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
 </pre></small>
    </blockquote>
-   <p>Modify <a href="http://eel.is/c++draft/unord.multimap.overview"> [unord.multimap.overview</a>] as follows:</p>
-   <p><small></small></p>
-   <blockquote>
-    <p></p>
-    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
-<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
-<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
-<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
-<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
-<c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
-              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
-              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
-              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
-              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
-</pre></small>
-   </blockquote>
    <p>Modify <a href="http://eel.is/c++draft/unord.set.overview"> [unord.set.overview</a>] as follows:</p>
    <p><small></small></p>
    <blockquote>

--- a/d1518-container-deduction-guides.html
+++ b/d1518-container-deduction-guides.html
@@ -2215,6 +2215,12 @@ From the second parameter, we deduce <code class="highlight"><c- n="">Allocator<
 We’ve deduced conflicting types for <code class="highlight"><c- n="">Allocator</c-></code>, so deduction fails.</p>
    <p>In this case, the second argument unnecessarily participates in deduction, and again unexpectedly
 prevents natural and useful code from working as desired.</p>
+   <p>To see  that
+the allocator argument is irrelevant to deduction, note that a vector can only be 
+constructed from a vector of the same type. E.g.,</p>
+<pre class="language-c++ highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-> <c- n="">pv2</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">);</c-> <c- c1="">// OK. Same types</c->
+<c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-> <c- n="">v</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-><c- p="">());</c->  <c- c1="">// Ill-formed. No such constructor</c->
+</pre>
    <h3 class="heading settled" data-level="3.3" id="solution2"><span class="secno">3.3. </span><span class="content">The solution</span><a class="self-link" href="#solution2"></a></h3>
    <p>If we were introducing the containers from scratch today, the natural approach would be for the
 constructors to indicate which arguments should be considered deducible, as is usual for function templates.</p>

--- a/d1518-container-deduction-guides.html
+++ b/d1518-container-deduction-guides.html
@@ -1,8 +1,8 @@
-<!doctype html><html lang="en">
- <head>
-  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <title>D1518R0: Stop overconstraining allocators in container deduction guides</title>
+  <title>D1518R1: Stop overconstraining allocators in container deduction guides</title>
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
  *
@@ -26,6 +26,7 @@
  *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
  *     -> .sidefigure for right-floated figures
  *   - ins/del
+ *     -> ins/del.c### for candidate and proposed changes (amendments)
  *
  * Code
  *   - pre and code
@@ -34,9 +35,12 @@
  *   - .note       for informative notes             (div, p, span, aside, details)
  *   - .example    for informative examples          (div, p, pre, span)
  *   - .issue      for issues                        (div, p, span)
- *   - .assertion  for assertions                    (div, p, span)
  *   - .advisement for loud normative statements     (div, p, strong)
  *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *   - .correction for "candidate corrections"       (div, aside, details, section)
+ *   - .addition   for "candidate additions"         (div, aside, details, section)
+ *   - .correction.proposed for "proposed corrections" (div, aside, details, section)
+ *   - .addition.proposed   for "proposed additions"   (div, aside, details, section)
  *
  * Definition Boxes
  *   - pre.def   for WebIDL definitions
@@ -57,6 +61,8 @@
  *   - .head for the header
  *   - .copyright for the copyright
  *
+ * Outdated warning for old specs
+ *
  * Miscellaneous
  *   - .overlarge for things that should be as wide as possible, even if
  *     that overflows the body text area. This can be used on an item or
@@ -64,22 +70,28 @@
  *     Note that this styling basically doesn't help at all when printing,
  *     since A4 paper isn't much wider than the max-width here.
  *     It's better to design things to fit into a narrower measure if possible.
+ *
  *   - js-added ToC jump links (see fixup.js)
  *
  ******************************************************************************/
 
+/* color variables included separately for reliability */
+
 /******************************************************************************/
-/*                                   Body                                     */
+/*                                    Body                                    */
 /******************************************************************************/
+
+	html {
+	}
 
 	body {
 		counter-reset: example figure issue;
 
 		/* Layout */
-		max-width: 50em;               /* limit line length to 50em for readability   */
-		margin: 0 auto;                /* center text within page                     */
+		max-width: 50em;			  /* limit line length to 50em for readability   */
+		margin: 0 auto;				/* center text within page                    */
 		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
-		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag    */
 
 		/* Typography */
 		line-height: 1.5;
@@ -90,9 +102,10 @@
 		overflow-wrap: break-word;
 		hyphens: auto;
 
-		/* Colors */
 		color: black;
+		color: var(--text);
 		background: white top left fixed no-repeat;
+		background: var(--bg) top left fixed no-repeat;
 		background-size: 25px auto;
 	}
 
@@ -103,7 +116,7 @@
 
 /** Header ********************************************************************/
 
-	div.head { margin-bottom: 1em }
+	div.head { margin-bottom: 1em; }
 	div.head hr { border-style: solid; }
 
 	div.head h1 {
@@ -124,10 +137,13 @@
 	.head img[src*="logos/W3C"] {
 		display: block;
 		border: solid #1a5e9a;
+		border: solid var(--logo-bg);
 		border-width: .65rem .7rem .6rem;
 		border-radius: .4rem;
 		background: #1a5e9a;
+		background: var(--logo-bg);
 		color: white;
+		color: var(--logo-text);
 		font-weight: bold;
 	}
 
@@ -138,7 +154,9 @@
 
 	.head a:active > img[src*="logos/W3C"] {
 		background: #c00;
+		background: var(--logo-active-bg);
 		border-color: #c00;
+		border-color: var(--logo-active-bg);
 	}
 
 	/* see also additional rules in Link Styling section */
@@ -146,7 +164,7 @@
 /** Copyright *****************************************************************/
 
 	p.copyright,
-	p.copyright small { font-size: small }
+	p.copyright small { font-size: small; }
 
 /** Back to Top / ToC Toggle **************************************************/
 
@@ -158,14 +176,13 @@
 	@media not print {
 		#toc-nav {
 			position: fixed;
-			z-index: 2;
+			z-index: 3;
 			bottom: 0; left: 0;
 			margin: 0;
 			min-width: 1.33em;
 			border-top-right-radius: 2rem;
 			box-shadow: 0 0 2px;
 			font-size: 1.5em;
-			color: black;
 		}
 		#toc-nav > a {
 			display: block;
@@ -175,23 +192,32 @@
 			padding: .1em 0.3em;
 			margin: 0;
 
-			background: white;
 			box-shadow: 0 0 2px;
 			border: none;
 			border-top-right-radius: 1.33em;
+
+			color: #707070;
+			color: var(--tocnav-normal-text);
 			background: white;
+			background: var(--tocnav-normal-bg);
 		}
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			color: black;
+			color: var(--tocnav-hover-text);
+			background: #f8f8f8;
+			background: var(--tocnav-hover-bg);
+		}
+		#toc-nav > a:active {
+			color: #c00;
+			color: var(--tocnav-active-text);
+			background: white;
+			background: var(--tocnav-active-bg);
+		}
+
 		#toc-nav > #toc-jump {
 			padding-bottom: 2em;
 			margin-bottom: -1.9em;
-		}
-
-		#toc-nav > a:hover,
-		#toc-nav > a:focus {
-			background: #f8f8f8;
-		}
-		#toc-nav > a:not(:hover):not(:focus) {
-			color: #707070;
 		}
 
 		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
@@ -205,26 +231,6 @@
 		}
 		#toc-nav > a > span + span {
 			padding-right: 0.2em;
-		}
-
-		#toc-toggle-inline {
-			vertical-align: 0.05em;
-			font-size: 80%;
-			color: gray;
-			color: hsla(203,20%,40%,.7);
-			border-style: none;
-			background: transparent;
-			position: relative;
-		}
-		#toc-toggle-inline:hover:not(:active),
-		#toc-toggle-inline:focus:not(:active) {
-			text-shadow: 1px 1px silver;
-			top: -1px;
-			left: -1px;
-		}
-
-		#toc-nav :active {
-			color: #C00;
 		}
 	}
 
@@ -243,10 +249,14 @@
 			padding: 0 1em;
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--tocsidebar-text);
 			background: inherit;
 			background-color: #f7f8f9;
+			background-color: var(--tocsidebar-bg);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
 		}
 		body.toc-sidebar #toc h2 {
 			margin-top: .8rem;
@@ -256,6 +266,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
+			color: var(--tocsidebar-heading-text);
 		}
 		body.toc-sidebar #toc-jump:not(:focus) {
 			width: 0;
@@ -283,10 +294,14 @@
 			padding: 0 1em;
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--tocsidebar-text);
 			background: inherit;
 			background-color: #f7f8f9;
+			background-color: var(--tocsidebar-bg);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
 		}
 		body:not(.toc-inline) #toc h2 {
 			margin-top: .8rem;
@@ -296,6 +311,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
+			color: var(--tocsidebar-heading-text);
 		}
 
 		body:not(.toc-inline) {
@@ -327,9 +343,9 @@
 		page-break-after: avoid;
 		page-break-inside: avoid;
 		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
-		font-family: inherit;    /* Inherit the font family. */
-		line-height: 1.2;        /* Keep wrapped headings compact */
-		hyphens: manual;         /* Hyphenated headings look weird */
+		font-family: inherit;	/* Inherit the font family. */
+		line-height: 1.2;		/* Keep wrapped headings compact */
+		hyphens: manual;		/* Hyphenated headings look weird */
 	}
 
 	h2, h3, h4, h5, h6 {
@@ -338,7 +354,7 @@
 
 	h1, h2, h3 {
 		color: #005A9C;
-		background: transparent;
+		color: var(--heading-text);
 	}
 
 	h1 { font-size: 170%; }
@@ -365,11 +381,13 @@
 
 /** Section divider ***********************************************************/
 
-	:not(.head) > hr {
+	:not(.head) > :not(.head) + hr {
 		font-size: 1.5em;
 		text-align: center;
 		margin: 1em auto;
 		height: auto;
+		color: black;
+		color: var(--hr-text);
 		border: transparent solid 0;
 		background: transparent;
 	}
@@ -411,48 +429,51 @@
 	/* Style for algorithms */
 	ol.algorithm ol:not(.algorithm),
 	.algorithm > ol ol:not(.algorithm) {
-	 border-left: 0.5em solid #DEF;
+	border-left: 0.5em solid #DEF;
+	border-left: 0.5em solid var(--algo-border);
 	}
 
 	/* Put nice boxes around each algorithm. */
 	[data-algorithm]:not(.heading) {
-	  padding: .5em;
-	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em calc(-0.5em - 1px);
+	 padding: .5em;
+	 border: thin solid #ddd;
+	 border: thin solid var(--algo-border);
+	 border-radius: .5em;
+	 margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
-	  margin-top: 0;
+	 margin-top: 0;
 	}
 	[data-algorithm]:not(.heading) > :last-child {
-	  margin-bottom: 0;
+	 margin-bottom: 0;
 	}
 
 	/* Style for switch/case <dl>s */
 	dl.switch > dd > ol.only,
 	dl.switch > dd > .only > ol {
-	 margin-left: 0;
+	margin-left: 0;
 	}
 	dl.switch > dd > ol.algorithm,
 	dl.switch > dd > .algorithm > ol {
-	 margin-left: -2em;
+	margin-left: -2em;
 	}
 	dl.switch {
-	 padding-left: 2em;
+	padding-left: 2em;
 	}
 	dl.switch > dt {
-	 text-indent: -1.5em;
-	 margin-top: 1em;
+	text-indent: -1.5em;
+	margin-top: 1em;
 	}
 	dl.switch > dt + dt {
-	 margin-top: 0;
+	margin-top: 0;
 	}
 	dl.switch > dt::before {
-	 content: '\21AA';
-	 padding: 0 0.5em 0 0;
-	 display: inline-block;
-	 width: 1em;
-	 text-align: right;
-	 line-height: 0.5em;
+	content: '\21AA';
+	padding: 0 0.5em 0 0;
+	display: inline-block;
+	width: 1em;
+	text-align: right;
+	line-height: 0.5em;
 	}
 
 /** Terminology Markup ********************************************************/
@@ -470,7 +491,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: medium;
+		font-size: inherit;
 	}
 	dfn var {
 		font-style: normal;
@@ -478,8 +499,39 @@
 
 /** Change Marking ************************************************************/
 
-	del { color: red;  text-decoration: line-through; }
-	ins { color: #080; text-decoration: underline;    }
+	del {
+		color: #aa0000;
+		color: var(--del-text);
+		background: transparent;
+		background: var(--del-bg);
+		text-decoration: line-through;
+	}
+	ins {
+		color: #006100;
+		color: var(--ins-text);
+		background: transparent;
+		background: var(--ins-bg);
+		text-decoration: underline;
+	}
+
+	/* for amendments (candidate/proposed changes) */
+
+	.amendment ins, .correction ins, .addition ins,
+	ins[class^=c] {
+		text-decoration-style: dotted;
+	}
+	.amendment del, .correction del, .addition del,
+	del[class^=c] {
+		text-decoration-style: dotted;
+	}
+	.amendment.proposed ins, .correction.proposed ins, .addition.proposed ins,
+	ins[class^=c].proposed {
+		text-decoration-style: double;
+	}
+	.amendment.proposed del, .correction.proposed del, .addition.proposed del,
+	del[class^=c].proposed {
+		text-decoration-style: double;
+	}
 
 /** Miscellaneous improvements to inline formatting ***************************/
 
@@ -497,9 +549,14 @@
 	pre, code, samp {
 		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
 		font-size: .9em;
-		page-break-inside: avoid;
 		hyphens: none;
 		text-transform: none;
+		text-align: left;
+		text-align: start;
+		font-variant: normal;
+		orphans: 3;
+		widows: 3;
+		page-break-before: avoid;
 	}
 	pre code,
 	code code {
@@ -514,7 +571,7 @@
 
 /** Inline Code fragments *****************************************************/
 
-  /* Do something nice. */
+	/* Do something nice. */
 
 /******************************************************************************/
 /*                                    Links                                   */
@@ -525,14 +582,19 @@
 	/* We hyperlink a lot, so make it less intrusive */
 	a[href] {
 		color: #034575;
+		color: var(--a-normal-text);
 		text-decoration: none;
 		border-bottom: 1px solid #707070;
+		border-bottom: 1px solid var(--a-normal-underline);
 		/* Need a bit of extending for it to look okay */
 		padding: 0 1px 0;
 		margin: 0 -1px 0;
 	}
 	a:visited {
-		border-bottom-color: #BBB;
+		color: #034575;
+		color: var(--a-visited-text);
+		border-bottom-color: #bbb;
+		border-bottom-color: var(--a-visited-underline);
 	}
 
 	/* Use distinguishing colors when user is interacting with the link */
@@ -540,12 +602,15 @@
 	a[href]:hover {
 		background: #f8f8f8;
 		background: rgba(75%, 75%, 75%, .25);
+		background: var(--a-hover-bg);
 		border-bottom-width: 3px;
 		margin-bottom: -2px;
 	}
 	a[href]:active {
-		color: #C00;
-		border-color: #C00;
+		color: #c00;
+		color: var(--a-active-text);
+		border-color: #c00;
+		border-color: var(--a-active-underline);
 	}
 
 	/* Backout above styling for W3C logo */
@@ -564,8 +629,13 @@
 		border-style: none;
 	}
 
+	img, svg {
+		/* Intentionally not color-scheme aware. */
+		background: white;
+	}
+
 	/* For autogen numbers, add
-	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	  .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
 	*/
 
 	figure, .figure, .sidefigure {
@@ -573,10 +643,11 @@
 		text-align: center;
 		margin: 2.5em 0;
 	}
-	.figure img,    .sidefigure img,    figure img,
+	.figure img,	.sidefigure img,	figure img,
 	.figure object, .sidefigure object, figure object {
 		max-width: 100%;
 		margin: auto;
+		height: auto;
 	}
 	.figure pre, .sidefigure pre, figure pre {
 		text-align: left;
@@ -590,7 +661,7 @@
 		.sidefigure {
 			float: right;
 			width: 50%;
-			margin: 0 0 0.5em 0.5em
+			margin: 0 0 0.5em 0.5em;
 		}
 	}
 	.caption, figcaption, caption {
@@ -605,13 +676,15 @@
 	}
 
 	/* DL list is indented 2em, but figure inside it is not */
-	dd > .figure, dd > figure { margin-left: -2em }
+	dd > .figure, dd > figure { margin-left: -2em; }
 
 /******************************************************************************/
 /*                             Colored Boxes                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .assertion, .advisement, blockquote {
+	.issue, .note, .example, .assertion, .advisement, blockquote,
+	.amendment, .correction, .addition {
+		margin: 1em auto;
 		padding: .5em;
 		border: .5em;
 		border-left-style: solid;
@@ -622,88 +695,117 @@
 		border-right-style: solid;
 	}
 
-	.issue,
-	.note,
-	.example,
-	.advisement,
-	.assertion,
-	blockquote {
-		margin: 1em auto;
-	}
+	blockquote > :first-child,
 	.note  > p:first-child,
 	.issue > p:first-child,
-	blockquote > :first-child {
+	.amendment > p:first-child,
+	.correction > p:first-child,
+	.addition > p:first-child {
 		margin-top: 0;
 	}
-	blockquote > :last-child {
+	blockquote > :last-child,
+	.note  > p:last-child,
+	.issue > p:last-child,
+	.amendment > p:last-child,
+	.correction > p:last-child,
+	.addition > p:last-child {
 		margin-bottom: 0;
+	}
+
+
+	.issue::before, .issue > .marker,
+	.example::before, .example > .marker,
+	.note::before, .note > .marker,
+	details.note > summary > .marker,
+	.amendment::before, .amendment > .marker,
+	details.amendment > summary > .marker,
+	.addition::before, .addition > .marker,
+	addition.amendment > summary > .marker,
+	.correction::before, .correction > .marker,
+	correction.amendment > summary > .marker
+	{
+		text-transform: uppercase;
+		padding-right: 1em;
+	}
+
+	.example::before, .example > .marker {
+		display: block;
+		padding-right: 0em;
 	}
 
 /** Blockquotes ***************************************************************/
 
 	blockquote {
 		border-color: silver;
+		border-color: var(--blockquote-border);
+		background: transparent;
+		background: var(--blockquote-bg);
+		color: currentcolor;
+		color: var(--blockquote-text);
 	}
 
 /** Open issue ****************************************************************/
 
 	.issue {
-		border-color: #E05252;
-		background: #FBE9E9;
+		border-color: #e05252;
+		border-color: var(--issue-border);
+		background: #fbe9e9;
+		background: var(--issue-bg);
+		color: black;
+		color: var(--issue-text);
 		counter-increment: issue;
 		overflow: auto;
 	}
 	.issue::before, .issue > .marker {
-		text-transform: uppercase;
-		color: #AE1E1E;
-		padding-right: 1em;
-		text-transform: uppercase;
+		color: #831616;
+		color: var(--issueheading-text);
 	}
 	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
-	   or use class="marker" to mark up the issue number in source. */
+	  or use class="marker" to mark up the issue number in source. */
 
 /** Example *******************************************************************/
 
 	.example {
-		border-color: #E0CB52;
-		background: #FCFAEE;
+		border-color: #e0cb52;
+		border-color: var(--example-border);
+		background: #fcfaee;
+		background: var(--example-bg);
+		color: black;
+		color: var(--example-text);
 		counter-increment: example;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
-		text-transform: uppercase;
-		color: #827017;
-		min-width: 7.5em;
-		display: block;
+		color: #574b0f;
+		color: var(--exampleheading-text);
 	}
 	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
-	   or use class="marker" to mark up the example number in source. */
+	  or use class="marker" to mark up the example number in source. */
 
 /** Non-normative Note ********************************************************/
 
 	.note {
-		border-color: #52E052;
-		background: #E9FBE9;
+		border-color: #52e052;
+		border-color: var(--note-border);
+		background: #e9fbe9;
+		background: var(--note-bg);
+		color: black;
+		color: var(--note-text);
 		overflow: auto;
 	}
 
 	.note::before, .note > .marker,
-	details.note > summary::before,
-	details.note > summary > .marker {
-		text-transform: uppercase;
-		display: block;
-		color: hsl(120, 70%, 30%);
-	}
-	/* Add .note::before { content: "Note"; } for autogen label,
-	   or use class="marker" to mark up the label in source. */
-
 	details.note > summary {
-		display: block;
 		color: hsl(120, 70%, 30%);
+		color: var(--noteheading-text);
 	}
+	/* Add .note::before { content: "Note "; } for autogen label,
+	  or use class="marker" to mark up the label in source. */
+
 	details.note[open] > summary {
 		border-bottom: 1px silver solid;
+		border-bottom: 1px var(--notesummary-underline) solid;
 	}
 
 /** Assertion Box *************************************************************/
@@ -711,7 +813,11 @@
 
 	.assertion {
 		border-color: #AAA;
+		border-color: var(--assertion-border);
 		background: #EEE;
+		background: var(--assertion-bg);
+		color: black;
+		color: var(--assertion-text);
 	}
 
 /** Advisement Box ************************************************************/
@@ -719,15 +825,52 @@
 
 	.advisement {
 		border-color: orange;
+		border-color: var(--advisement-border);
 		border-style: none solid;
-		background: #FFEECC;
+		background: #fec;
+		background: var(--advisement-bg);
+		color: black;
+		color: var(--advisement-text);
 	}
 	strong.advisement {
 		display: block;
 		text-align: center;
 	}
-	.advisement > .marker {
-		color: #B35F00;
+	.advisement::before, .advisement > .marker {
+		color: #b35f00;
+		color: var(--advisementheading-text);
+	}
+
+/** Amendment Box *************************************************************/
+
+	.amendment, .correction, .addition {
+		border-color: #330099;
+		border-color: var(--amendment-border);
+		background: #F5F0FF;
+		background: var(--amendment-bg);
+		color: black;
+		color: var(--amendment-text);
+	}
+	.amendment.proposed, .correction.proposed, .addition.proposed {
+		border-style: solid;
+		border-block-width: 0.25em;
+	}
+	.amendment::before, .amendment > .marker,
+	details.amendment > summary::before, details.amendment > summary > .marker,
+	.correction::before, .correction > .marker,
+	details.correction > summary::before, details.correction > summary > .marker,
+	.addition::before, .addition > .marker,
+	details.addition > summary::before, details.addition > summary > .marker {
+		color: #220066;
+		color: var(--amendmentheading-text);
+	}
+	.amendment.proposed::before, .amendment.proposed > .marker,
+	details.amendment.proposed > summary::before, details.amendment.proposed > summary > .marker,
+	.correction.proposed::before, .correction.proposed > .marker,
+	details.correction.proposed > summary::before, details.correction.proposed > summary > .marker,
+	.addition.proposed::before, .addition.proposed > .marker,
+	details.addition.proposed > summary::before, details.addition.proposed > summary > .marker {
+		font-weight: bold;
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
@@ -743,13 +886,16 @@
 	.annoying-warning:not(details),
 	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
-		background: #fdd;
-		color: red;
-		font-weight: bold;
+		background: hsla(40,100%,50%,0.95);
+		background: var(--warning-bg);
+		color: black;
+		color: var(--warning-text);
 		padding: .75em 1em;
-		border: thick red;
-		border-style: solid;
-		border-radius: 1em;
+		border: red;
+		border: var(--warning-border);
+		border-style: solid none;
+		box-shadow: 0 2px 8px black;
+		text-align: center;
 	}
 	.annoying-warning :last-child {
 		margin-bottom: 0;
@@ -758,9 +904,9 @@
 @media not print {
 	details.annoying-warning[open] {
 		position: fixed;
-		left: 1em;
-		right: 1em;
-		bottom: 1em;
+		left: 0;
+		right: 0;
+		bottom: 2em;
 		z-index: 1000;
 	}
 }
@@ -773,9 +919,13 @@
 
 	.def {
 		padding: .5em 1em;
-		background: #DEF;
+		background: #def;
+		background: var(--def-bg);
 		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
+		border-left: 0.5em solid #8ccbf2;
+		border-left: 0.5em solid var(--def-border);
+		color: black;
+		color: var(--def-text);
 	}
 
 /******************************************************************************/
@@ -800,6 +950,7 @@
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
+		border-bottom: 1px solid var(--defrow-border);
 	}
 
 	table.def > tbody > tr:last-child th,
@@ -820,10 +971,10 @@
 	}
 
 	/* A footnote at the bottom of a def table */
-	table.def           td.footnote {
+	table.def td.footnote {
 		padding-top: 0.6em;
 	}
-	table.def           td.footnote::before {
+	table.def td.footnote::before {
 		content: " ";
 		display: block;
 		height: 0.6em;
@@ -833,15 +984,15 @@
 
 /** Data tables (and properly marked-up index tables) *************************/
 	/*
-		 <table class="data"> highlights structural relationships in a table
-		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+		<table class="data"> highlights structural relationships in a table
+		when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
 
-		 Use class="complex data" for particularly complicated tables --
-		 (This will draw more lines: busier, but clearer.)
+		Use class="complex data" for particularly complicated tables --
+		(This will draw more lines: busier, but clearer.)
 
-		 Use class="long" on table cells with paragraph-like contents
-		 (This will adjust text alignment accordingly.)
-		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+		Use class="long" on table cells with paragraph-like contents
+		(This will adjust text alignment accordingly.)
+		Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
 
 	table {
@@ -868,6 +1019,7 @@
 		padding: 0.5em 1em;
 		border-width: 1px;
 		border-color: silver;
+		border-color: var(--datacell-border);
 		border-top-style: solid;
 	}
 
@@ -892,6 +1044,7 @@
 	table.index tbody th:first-child  {
 		border-right: 2px solid;
 		border-top: 1px solid silver;
+		border-top: 1px solid var(--datacell-border);
 		padding-right: 1em;
 	}
 
@@ -903,13 +1056,14 @@
 	table.complex.data th,
 	table.complex.data td {
 		border: 1px solid silver;
+		border: 1px solid var(--datacell-border);
 		text-align: center;
 	}
 
 	table.data.longlastcol td:last-child,
 	table.data td.long {
-	 vertical-align: baseline;
-	 text-align: left;
+		vertical-align: baseline;
+		text-align: left;
 	}
 
 	table.data img {
@@ -967,12 +1121,15 @@ Possible extra rowspan handling
 		display: block;
 		/* Reverse color scheme */
 		color: black;
-		border-color: #3980B5;
-		border-bottom-width: 3px !important;
-		margin-bottom: 0px !important;
+		color: var(--toclink-text);
+		border-color: #3980b5;
+		border-color: var(--toclink-underline);
 	}
 	.toc a:visited {
+		color: black;
+		color: var(--toclink-visited-text);
 		border-color: #054572;
+		border-color: var(--toclink-visited-underline);
 	}
 	.toc a:not(:focus):not(:hover) {
 		/* Allow colors to cascade through from link styling */
@@ -984,22 +1141,22 @@ Possible extra rowspan handling
 		/* because generated content isn't search/selectable and markers can't do multilevel yet */
 		margin:  0;
 		padding: 0;
-		line-height: 1.1rem; /* consistent spacing */
+	}
+	.toc {
+		line-height: 1.1em;
 	}
 
 	/* ToC not indented until third level, but font style & margins show hierarchy */
-	.toc > li             { font-weight: bold;   }
-	.toc > li li          { font-weight: normal; }
-	.toc > li li li       { font-size:   95%;    }
-	.toc > li li li li    { font-size:   90%;    }
-	.toc > li li li li .secno { font-size: 85%; }
-	.toc > li li li li li { font-size:   85%;    }
-	.toc > li li li li li .secno { font-size: 100%; }
+	.toc > li			{ font-weight: bold;   }
+	.toc > li li		 { font-weight: normal; }
+	.toc > li li li	  { font-size:   95%;	}
+	.toc > li li li li	{ font-size:   90%;	}
+	.toc > li li li li li { font-size:   85%;	}
 
 	/* @supports not (display:grid) { */
-		.toc > li             { margin: 1.5rem 0;    }
-		.toc > li li          { margin: 0.3rem 0;    }
-		.toc > li li li       { margin-left: 2rem;   }
+		.toc > li			{ margin: 1.5rem 0;	}
+		.toc > li li		 { margin: 0.3rem 0;	}
+		.toc > li li li	  { margin-left: 2rem;   }
 
 		/* Section numbers in a column of their own */
 		.toc .secno {
@@ -1007,29 +1164,40 @@ Possible extra rowspan handling
 			width: 4rem;
 			white-space: nowrap;
 		}
+		.toc > li li li li .secno { font-size: 85%; }
+		.toc > li li li li li .secno { font-size: 100%; }
 
 		.toc li {
 			clear: both;
 		}
 
-		:not(li) > .toc              { margin-left:  5rem; }
-		.toc .secno                  { margin-left: -5rem; }
-		.toc > li li li .secno       { margin-left: -7rem; }
-		.toc > li li li li .secno    { margin-left: -9rem; }
+		:not(li) > .toc			 { margin-left:  5rem; }
+		.toc .secno				 { margin-left: -5rem; }
+		.toc > li li li .secno	  { margin-left: -7rem; }
+		.toc > li li li li .secno	{ margin-left: -9rem; }
 		.toc > li li li li li .secno { margin-left: -11rem; }
 
 		/* Tighten up indentation in narrow ToCs */
 		@media (max-width: 30em) {
-			:not(li) > .toc              { margin-left:  4rem; }
-			.toc .secno                  { margin-left: -4rem; }
-			.toc > li li li              { margin-left:  1rem; }
-			.toc > li li li .secno       { margin-left: -5rem; }
-			.toc > li li li li .secno    { margin-left: -6rem; }
+			:not(li) > .toc			 { margin-left:  4rem; }
+			.toc .secno				 { margin-left: -4rem; }
+			.toc > li li li			 { margin-left:  1rem; }
+			.toc > li li li .secno	  { margin-left: -5rem; }
+			.toc > li li li li .secno	{ margin-left: -6rem; }
 			.toc > li li li li li .secno { margin-left: -7rem; }
 		}
+		/* Loosen it on wide screens */
+		@media screen and (min-width: 78em) {
+			body:not(.toc-inline) :not(li) > .toc			 { margin-left:  4rem; }
+			body:not(.toc-inline) .toc .secno				 { margin-left: -4rem; }
+			body:not(.toc-inline) .toc > li li li			 { margin-left:  1rem; }
+			body:not(.toc-inline) .toc > li li li .secno	  { margin-left: -5rem; }
+			body:not(.toc-inline) .toc > li li li li .secno	{ margin-left: -6rem; }
+			body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1055,7 +1223,7 @@ Possible extra rowspan handling
 		}
 		#toc > .toc > li > a > span {
 			/* The spans of the top-level list,
-			   comprising the first items of each top-level section. */
+			  comprising the first items of each top-level section. */
 			margin-top: 1.1rem;
 		}
 		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
@@ -1068,9 +1236,12 @@ Possible extra rowspan handling
 			width: auto;
 			margin-right: 1rem;
 		}
-		#toc .content:hover {
+		#toc .content:hover,
+		#toc .content:focus {
 			background: rgba(75%, 75%, 75%, .25);
+			background: var(--a-hover-bg);
 			border-bottom: 3px solid #054572;
+			border-bottom: 3px solid var(--toclink-underline);
 			margin-bottom: -3px;
 		}
 		#toc li li li .content {
@@ -1085,22 +1256,23 @@ Possible extra rowspan handling
 /** Index *********************************************************************/
 
 	/* Index Lists: Layout */
-	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
-	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
-	ul.index li li { margin-left: 1em }
-	ul.index dl    { margin-top: 0; }
-	ul.index dt    { margin: .2em 0 .2em 20px;}
-	ul.index dd    { margin: .2em 0 .2em 40px;}
+	ul.index	  { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li	{ margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em; }
+	ul.index dl	{ margin-top: 0; }
+	ul.index dt	{ margin: .2em 0 .2em 20px;}
+	ul.index dd	{ margin: .2em 0 .2em 40px;}
 	/* Index Lists: Typography */
 	ul.index ul,
 	ul.index dl { font-size: smaller; }
 	@media not print {
-		ul.index li span {
+		ul.index li span:not(.dfn-paneled) {
 			white-space: nowrap;
 			color: transparent; }
 		ul.index li a:hover + span,
 		ul.index li a:focus + span {
 			color: #707070;
+			color: var(--indexinfo-text);
 		}
 	}
 
@@ -1122,13 +1294,101 @@ Possible extra rowspan handling
 
 	table.index tr:hover td:not([rowspan]),
 	table.index tr:hover th:not([rowspan]) {
+		color: black;
+		color: var(--indextable-hover-text);
 		background: #f7f8f9;
+		background: var(--indextable-hover-bg);
 	}
 
 	/* The link in the first column in the property table (formerly a TD) */
 	table.index th:first-child a {
 		font-weight: bold;
 	}
+
+/** Outdated warning **********************************************************/
+
+.outdated-spec {
+	color: black;
+	color: var(--outdatedspec-text);
+	background-color: rgba(0,0,0,0.5);
+	background-color: var(--outdatedspec-bg);
+}
+
+.outdated-warning {
+	position: fixed;
+	bottom: 50%;
+	left: 0;
+	right: 0;
+	margin: 0 auto;
+	width: 50%;
+	background: maroon;
+	background: var(--outdated-bg);
+	color: white;
+	color: var(--outdated-text);
+	border-radius: 1em;
+	box-shadow: 0 0 1em red;
+	box-shadow: 0 0 1em var(--outdated-shadow);
+	padding: 2em;
+	text-align: center;
+	z-index: 2;
+}
+
+.outdated-warning a {
+	color: currentcolor;
+	background: transparent;
+}
+
+.edited-rec-warning {
+	background: darkorange;
+	background: var(--editedrec-bg);
+	box-shadow: 0 0 1em;
+}
+
+.outdated-warning button {
+	color: var(--outdated-text);
+	border-radius: 1em;
+	box-shadow: 0 0 1em red;
+	box-shadow: 0 0 1em var(--outdated-shadow);
+	padding: 2em;
+	text-align: center;
+	z-index: 2;
+}
+
+.outdated-warning a {
+	color: currentcolor;
+	background: transparent;
+}
+
+.edited-rec-warning {
+	background: darkorange;
+	background: var(--editedrec-bg);
+	box-shadow: 0 0 1em;
+}
+
+.outdated-warning button {
+	position: absolute;
+	top: 0;
+	right:0;
+	margin: 0;
+	border: 0;
+	padding: 0.25em 0.5em;
+	background: transparent;
+	color: white;
+	color: var(--outdated-text);
+	font:1em sans-serif;
+	text-align:center;
+}
+
+.outdated-warning span {
+	display: block;
+}
+
+.outdated-collapsed {
+	bottom: 0;
+	border-radius: 0;
+	width: 100%;
+	padding: 0;
+}
 
 /******************************************************************************/
 /*                                    Print                                   */
@@ -1143,17 +1403,20 @@ Possible extra rowspan handling
 		body {
 			font-family: serif;
 		}
+
+		.outdated-warning {
+			position: absolute;
+			border-style: solid;
+			border-color: red;
+		}
+
+		.outdated-warning input {
+			display: none;
+		}
 	}
 	@page {
 		margin: 1.5cm 1.1cm;
 	}
-
-/******************************************************************************/
-/*                                    Legacy                                  */
-/******************************************************************************/
-
-	/* This rule is inherited from past style sheets. No idea what it's for. */
-	.hide { display: none }
 
 
 
@@ -1167,6 +1430,18 @@ Possible extra rowspan handling
 		margin-left: auto;
 		margin-right: auto;
 	}
+	.overlarge {
+		/* Magic to create good item positioning:
+		  "content column" is 50ems wide at max; less on smaller screens.
+		  Extra space (after ToC + content) is empty on the right.
+
+		  1. When item < content column, centers item in column.
+		  2. When content < item < available, left-aligns.
+		  3. When item > available, fills available + scroll bar.
+		*/
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
 	.overlarge > table {
 		/* limit preferred width of table */
 		max-width: 50em;
@@ -1176,7 +1451,6 @@ Possible extra rowspan handling
 
 	@media (min-width: 55em) {
 		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
 			margin-right: calc(13px + 26.5rem - 50vw);
 			max-width: none;
 		}
@@ -1184,14 +1458,12 @@ Possible extra rowspan handling
 	@media screen and (min-width: 78em) {
 		body:not(.toc-inline) .overlarge {
 			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
 			margin-right: calc(40em - 50vw) !important;
 		}
 	}
 	@media screen and (min-width: 90em) {
 		body:not(.toc-inline) .overlarge {
 			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
 			margin-right: calc(84.5em - 100vw) !important;
 		}
 	}
@@ -1200,13 +1472,13 @@ Possible extra rowspan handling
 		.overlarge {
 			overflow-x: auto;
 			/* See Lea Verou's explanation background-attachment:
-			 * http://lea.verou.me/2012/04/background-attachment-local/
-			 *
+			* http://lea.verou.me/2012/04/background-attachment-local/
+			*
 			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
-			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
-			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
-			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
-			            white;
+						top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+						top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+						top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+						white;
 			background-repeat: no-repeat;
 			*/
 		}
@@ -1226,160 +1498,75 @@ Possible extra rowspan handling
     th {
       text-align: center;
     }
+
+    del { background: #fcc; color: #000; text-decoration: line-through; }
+    ins { background: #cfc; color: #000; }
+    blockquote .highlight:not(.idl) { background: initial; margin: initial; padding: 0.5em }
+    blockquote ul { background: inherit; }
+    blockquote code.highlight:not(.idl) { padding: initial; }
+    blockquote c-[a] { color: inherit; } /* Keyword.Declaration */
+    blockquote c-[b] { color: inherit; } /* Keyword.Type */
+    blockquote c-[c] { color: inherit; } /* Comment */
+    blockquote c-[d] { color: inherit; } /* Comment.Multiline */
+    blockquote c-[e] { color: inherit; } /* Name.Attribute */
+    blockquote c-[f] { color: inherit; } /* Name.Tag */
+    blockquote c-[g] { color: inherit; } /* Name.Variable */
+    blockquote c-[k] { color: inherit; } /* Keyword */
+    blockquote c-[l] { color: inherit; } /* Literal */
+    blockquote c-[m] { color: inherit; } /* Literal.Number */
+    blockquote c-[n] { color: inherit; } /* Name */
+    blockquote c-[o] { color: inherit; } /* Operator */
+    blockquote c-[p] { color: inherit; } /* Punctuation */
+    blockquote c-[s] { color: inherit; } /* Literal.String */
+    blockquote c-[t] { color: inherit; } /* Literal.String.Single */
+    blockquote c-[u] { color: inherit; } /* Literal.String.Double */
+    blockquote c-[cp] { color: inherit; } /* Comment.Preproc */
+    blockquote c-[c1] { color: inherit; } /* Comment.Single */
+    blockquote c-[cs] { color: inherit; } /* Comment.Special */
+    blockquote c-[kc] { color: inherit; } /* Keyword.Constant */
+    blockquote c-[kn] { color: inherit; } /* Keyword.Namespace */
+    blockquote c-[kp] { color: inherit; } /* Keyword.Pseudo */
+    blockquote c-[kr] { color: inherit; } /* Keyword.Reserved */
+    blockquote c-[ld] { color: inherit; } /* Literal.Date */
+    blockquote c-[nc] { color: inherit; } /* Name.Class */
+    blockquote c-[no] { color: inherit; } /* Name.Constant */
+    blockquote c-[nd] { color: inherit; } /* Name.Decorator */
+    blockquote c-[ni] { color: inherit; } /* Name.Entity */
+    blockquote c-[ne] { color: inherit; } /* Name.Exception */
+    blockquote c-[nf] { color: inherit; } /* Name.Function */
+    blockquote c-[nl] { color: inherit; } /* Name.Label */
+    blockquote c-[nn] { color: inherit; } /* Name.Namespace */
+    blockquote c-[py] { color: inherit; } /* Name.Property */
+    blockquote c-[ow] { color: inherit; } /* Operator.Word */
+    blockquote c-[mb] { color: inherit; } /* Literal.Number.Bin */
+    blockquote c-[mf] { color: inherit; } /* Literal.Number.Float */
+    blockquote c-[mh] { color: inherit; } /* Literal.Number.Hex */
+    blockquote c-[mi] { color: inherit; } /* Literal.Number.Integer */
+    blockquote c-[mo] { color: inherit; } /* Literal.Number.Oct */
+    blockquote c-[sb] { color: inherit; } /* Literal.String.Backtick */
+    blockquote c-[sc] { color: inherit; } /* Literal.String.Char */
+    blockquote c-[sd] { color: inherit; } /* Literal.String.Doc */
+    blockquote c-[se] { color: inherit; } /* Literal.String.Escape */
+    blockquote c-[sh] { color: inherit; } /* Literal.String.Heredoc */
+    blockquote c-[si] { color: inherit; } /* Literal.String.Interpol */
+    blockquote c-[sx] { color: inherit; } /* Literal.String.Other */
+    blockquote c-[sr] { color: inherit; } /* Literal.String.Regex */
+    blockquote c-[ss] { color: inherit; } /* Literal.String.Symbol */
+    blockquote c-[vc] { color: inherit; } /* Name.Variable.Class */
+    blockquote c-[vg] { color: inherit; } /* Name.Variable.Global */
+    blockquote c-[vi] { color: inherit; } /* Name.Variable.Instance */
+    blockquote c-[il] { color: inherit; } /* Literal.Number.Integer.Long */
   </style>
-  <meta content="Bikeshed version c03af8da7325f5ae3f9ca742161b5d270bbce12f" name="generator">
+  <meta content="Bikeshed version 4e8dd937, updated Fri Nov 13 16:49:31 2020 -0800" name="generator">
   <link href="https://isocpp.org/favicon.ico" rel="icon">
 <style>
 ins  {background-color: #CCFFCC; text-decoration: underline;}
 del  {background-color: #FFCACA; text-decoration: line-through;}
 </style>
-<style>/* style-md-lists */
-
-/* This is a weird hack for me not yet following the commonmark spec
-   regarding paragraph and lists. */
-[data-md] > :first-child {
-    margin-top: 0;
-}
-[data-md] > :last-child {
-    margin-bottom: 0;
-}</style>
-<style>/* style-counters */
-
-body {
-    counter-reset: example figure issue;
-}
-.issue {
-    counter-increment: issue;
-}
-.issue:not(.no-marker)::before {
-    content: "Issue " counter(issue);
-}
-
-.example {
-    counter-increment: example;
-}
-.example:not(.no-marker)::before {
-    content: "Example " counter(example);
-}
-.invalid.example:not(.no-marker)::before,
-.illegal.example:not(.no-marker)::before {
-    content: "Invalid Example" counter(example);
-}
-
-figcaption {
-    counter-increment: figure;
-}
-figcaption:not(.no-marker)::before {
-    content: "Figure " counter(figure) " ";
-}</style>
-<style>/* style-syntax-highlighting */
-
-.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-code.highlight { padding: .1em; border-radius: .3em; }
-pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-c-[a] { color: #990055 } /* Keyword.Declaration */
-c-[b] { color: #990055 } /* Keyword.Type */
-c-[c] { color: #708090 } /* Comment */
-c-[d] { color: #708090 } /* Comment.Multiline */
-c-[e] { color: #0077aa } /* Name.Attribute */
-c-[f] { color: #669900 } /* Name.Tag */
-c-[g] { color: #222222 } /* Name.Variable */
-c-[k] { color: #990055 } /* Keyword */
-c-[l] { color: #000000 } /* Literal */
-c-[m] { color: #000000 } /* Literal.Number */
-c-[n] { color: #0077aa } /* Name */
-c-[o] { color: #999999 } /* Operator */
-c-[p] { color: #999999 } /* Punctuation */
-c-[s] { color: #a67f59 } /* Literal.String */
-c-[t] { color: #a67f59 } /* Literal.String.Single */
-c-[u] { color: #a67f59 } /* Literal.String.Double */
-c-[cp] { color: #708090 } /* Comment.Preproc */
-c-[c1] { color: #708090 } /* Comment.Single */
-c-[cs] { color: #708090 } /* Comment.Special */
-c-[kc] { color: #990055 } /* Keyword.Constant */
-c-[kn] { color: #990055 } /* Keyword.Namespace */
-c-[kp] { color: #990055 } /* Keyword.Pseudo */
-c-[kr] { color: #990055 } /* Keyword.Reserved */
-c-[ld] { color: #000000 } /* Literal.Date */
-c-[nc] { color: #0077aa } /* Name.Class */
-c-[no] { color: #0077aa } /* Name.Constant */
-c-[nd] { color: #0077aa } /* Name.Decorator */
-c-[ni] { color: #0077aa } /* Name.Entity */
-c-[ne] { color: #0077aa } /* Name.Exception */
-c-[nf] { color: #0077aa } /* Name.Function */
-c-[nl] { color: #0077aa } /* Name.Label */
-c-[nn] { color: #0077aa } /* Name.Namespace */
-c-[py] { color: #0077aa } /* Name.Property */
-c-[ow] { color: #999999 } /* Operator.Word */
-c-[mb] { color: #000000 } /* Literal.Number.Bin */
-c-[mf] { color: #000000 } /* Literal.Number.Float */
-c-[mh] { color: #000000 } /* Literal.Number.Hex */
-c-[mi] { color: #000000 } /* Literal.Number.Integer */
-c-[mo] { color: #000000 } /* Literal.Number.Oct */
-c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
-c-[sc] { color: #a67f59 } /* Literal.String.Char */
-c-[sd] { color: #a67f59 } /* Literal.String.Doc */
-c-[se] { color: #a67f59 } /* Literal.String.Escape */
-c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
-c-[si] { color: #a67f59 } /* Literal.String.Interpol */
-c-[sx] { color: #a67f59 } /* Literal.String.Other */
-c-[sr] { color: #a67f59 } /* Literal.String.Regex */
-c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
-c-[vc] { color: #0077aa } /* Name.Variable.Class */
-c-[vg] { color: #0077aa } /* Name.Variable.Global */
-c-[vi] { color: #0077aa } /* Name.Variable.Instance */
-c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
-</style>
-<style>/* style-selflinks */
-
-.heading, .issue, .note, .example, li, dt {
-    position: relative;
-}
-a.self-link {
-    position: absolute;
-    top: 0;
-    left: calc(-1 * (3.5rem - 26px));
-    width: calc(3.5rem - 26px);
-    height: 2em;
-    text-align: center;
-    border: none;
-    transition: opacity .2s;
-    opacity: .5;
-}
-a.self-link:hover {
-    opacity: 1;
-}
-.heading > a.self-link {
-    font-size: 83%;
-}
-li > a.self-link {
-    left: calc(-1 * (3.5rem - 26px) - 2em);
-}
-dfn > a.self-link {
-    top: auto;
-    left: auto;
-    opacity: 0;
-    width: 1.5em;
-    height: 1.5em;
-    background: gray;
-    color: white;
-    font-style: normal;
-    transition: opacity .2s, background-color .2s, color .2s;
-}
-dfn:hover > a.self-link {
-    opacity: 1;
-}
-dfn > a.self-link:hover {
-    color: black;
-}
-
-a.self-link::before            { content: "¶"; }
-.heading > a.self-link::before { content: "§"; }
-dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
-    color: #005a9c;
+    color: var(--a-normal-text);
     font-size: inherit;
     font-family: inherit;
 }
@@ -1438,29 +1625,470 @@ pre .property::before, pre .property::after {
 [data-link-type=biblio] {
     white-space: pre;
 }</style>
- <body class="h-entry">
+<style>/* style-colors */
+
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #707070;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #bbb;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}</style>
+<style>/* style-counters */
+
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
+<style>/* style-md-lists */
+
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
+<style>/* style-selflinks */
+
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* style-syntax-highlighting */
+
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
+<style>/* style-darkmode */
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ </head><body class="h-entry toc-sidebar"><p id="toc-nav"><a id="toc-jump" href="#toc"><span aria-hidden="true">↑</span> <span>Jump to Table of Contents</span></a><a id="toc-toggle" href="#toc"><span aria-hidden="true">←</span> <span>Collapse Sidebar</span></a></p>
   <div class="head">
    <p data-fill-with="logo"></p>
-   <h1 class="p-name no-ref" id="title">D1518R0<br>Stop overconstraining allocators in container deduction guides</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Proposal, <time class="dt-updated" datetime="2019-03-09">2019-03-09</time></span></h2>
+   <h1 class="p-name no-ref" id="title">D1518R1<br>Stop overconstraining allocators in container deduction guides</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Proposal, <time class="dt-updated" datetime="2021-02-13">2021-02-13</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
-     <dt>Authors:
-     <dd>
-      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:arthur.j.odwyer@gmail.com">Arthur O'Dwyer</a>
-     <dd>
-      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mike_spertus@symantec.com">Mike Spertus</a>
-     <dt>Audience:
-     <dd>LEWG
-     <dt>Project:
-     <dd>ISO/IEC JTC1/SC22/WG21 14882: Programming Language — C++
-     <dt>Draft Revision:
-     <dd>4
-     <dt>Current Source:
-     <dd><a href="https://github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs">github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs</a>
-     <dt>Current:
-     <dd><a href="https://rawgit.com/Quuxplusone/draft/gh-pages/stack-ctad.html">rawgit.com/Quuxplusone/draft/gh-pages/stack-ctad.html</a>
-    </dl>
+     <dt class="editor">Authors:
+     </dt><dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:arthur.j.odwyer@gmail.com">Arthur O'Dwyer</a>
+     </dd><dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:msspertu@amazon.com">Mike Spertus</a>
+     </dd><dt>Audience:
+     </dt><dd>LWG
+     </dd><dt>Project:
+     </dt><dd>ISO/IEC JTC1/SC22/WG21 14882: Programming Language — C++
+     </dd><dt>Draft Revision:
+     </dt><dd>0
+     </dd><dt>Current Source:
+     </dt><dd><a href="https://github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs">github.com/Quuxplusone/draft/blob/gh-pages/stack-ctad.bs</a>
+     </dd><dt>Current:
+     </dt><dd><a href="https://rawgit.com/Quuxplusone/draft/gh-pages/d1518-container-deduction-guides.html">https://rawgit.com/Quuxplusone/draft/gh-pages/d1518-container-deduction-guides.html</a>
+    </dd></dl>
    </div>
    <div data-fill-with="warning"></div>
    <hr title="Separator for header">
@@ -1475,279 +2103,349 @@ pre .property::before, pre .property::after {
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
-    <li>
-     <a href="#overconst1"><span class="secno">1</span> <span class="content">Stop overconstraining allocators that do not participate in deduction</span></a>
+    <li><a href="#changelog"><span class="secno">1</span> <span class="content">Changelog</span></a>
+    </li><li>
+     <a href="#overconst1"><span class="secno">2</span> <span class="content">Stop overconstraining allocators that do not participate in deduction</span></a>
      <ol class="toc">
-      <li><a href="#problem1"><span class="secno">1.1</span> <span class="content">The problem</span></a>
-      <li><a href="#explanation1"><span class="secno">1.2</span> <span class="content">The explanation</span></a>
-      <li><a href="#solution1"><span class="secno">1.3</span> <span class="content">The solution</span></a>
-     </ol>
-    <li>
-     <a href="#overconst2"><span class="secno">2</span> <span class="content">Stop deducing from allocators that should not participate in deduction</span></a>
+      <li><a href="#problem1"><span class="secno">2.1</span> <span class="content">The problem</span></a>
+      </li><li><a href="#explanation1"><span class="secno">2.2</span> <span class="content">The explanation</span></a>
+      </li><li><a href="#solution1"><span class="secno">2.3</span> <span class="content">The solution</span></a>
+     </li></ol>
+    </li><li>
+     <a href="#overconst2"><span class="secno">3</span> <span class="content">Stop deducing from allocators that should not participate in deduction</span></a>
      <ol class="toc">
-      <li><a href="#problem2"><span class="secno">2.1</span> <span class="content">The problem</span></a>
-      <li><a href="#explanation2"><span class="secno">2.2</span> <span class="content">The explanation</span></a>
-      <li>
-       <a href="#solution2"><span class="secno">2.3</span> <span class="content">The solution</span></a>
-       <ol class="toc">
-        <li><a href="#option1"><span class="secno">2.3.1</span> <span class="content">Wording option 1</span></a>
-        <li><a href="#option2"><span class="secno">2.3.2</span> <span class="content">Wording option 2</span></a>
-       </ol>
-      <li><a href="#implementation"><span class="secno">2.4</span> <span class="content">Implementation note</span></a>
-     </ol>
-   </ol>
+      <li><a href="#problem2"><span class="secno">3.1</span> <span class="content">The problem</span></a>
+      </li><li><a href="#explanation2"><span class="secno">3.2</span> <span class="content">The explanation</span></a>
+      </li><li><a href="#solution2"><span class="secno">3.3</span> <span class="content">The solution</span></a>
+      </li><li><a href="#implementation"><span class="secno">3.4</span> <span class="content">Implementation note</span></a>
+     </li></ol>
+   </li></ol>
   </nav>
   <main>
-   <h2 class="heading settled" data-level="1" id="overconst1"><span class="secno">1. </span><span class="content">Stop overconstraining allocators that do not participate in deduction</span><a class="self-link" href="#overconst1"></a></h2>
-   <h3 class="heading settled" data-level="1.1" id="problem1"><span class="secno">1.1. </span><span class="content">The problem</span><a class="self-link" href="#problem1"></a></h3>
+   <h2 class="heading settled" data-level="1" id="changelog"><span class="secno">1. </span><span class="content">Changelog</span><a class="self-link" href="#changelog"></a></h2>
+   <ul>
+    <li data-md="">
+     <p>R1: Incorporate LWG feedback on wording in <a href="#overconst1">§ 2 Stop overconstraining allocators that do not participate in deduction</a> and to adopt Wording Option 1 in <a href="#overconst2">§ 3 Stop deducing from allocators that should not participate in deduction</a></p>
+   </li></ul>
+   <h2 class="heading settled" data-level="2" id="overconst1"><span class="secno">2. </span><span class="content">Stop overconstraining allocators that do not participate in deduction</span><a class="self-link" href="#overconst1"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="problem1"><span class="secno">2.1. </span><span class="content">The problem</span><a class="self-link" href="#problem1"></a></h3>
    <p>Consider this code:</p>
-<pre class="language-c++ highlight"><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-> <c- n>mr</c-><c- p>;</c->
-<c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-> <c- n>a</c-> <c- o>=</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>;</c->
-<c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-> <c- n>pv</c-><c- p>(</c-><c- n>a</c-><c- p>);</c->
+<pre class="language-c++ highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-> <c- n="">mr</c-><c- p="">;</c->
+<c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">;</c->
+<c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-> <c- n="">pv</c-><c- p="">(</c-><c- n="">a</c-><c- p="">);</c->
 
-<c- k>auto</c-> <c- n>s1</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>s2</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- n>a</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>s3</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>);</c->
+<c- k="">auto</c-> <c- n="">s1</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">s2</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- n="">a</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">s3</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">);</c->
 
-<c- k>auto</c-> <c- n>ds1</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- p>(</c-><c- n>pv</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>ds2</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- n>a</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>ds3</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>stack</c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>);</c->
+<c- k="">auto</c-> <c- n="">ds1</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">ds2</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- n="">a</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">ds3</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">stack</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">);</c->
 </pre>
-   <p>The initializers of <code class="highlight"><c- n>s1</c-></code>, <code class="highlight"><c- n>s2</c-></code>, and <code class="highlight"><c- n>s3</c-></code> (which do not use CTAD) are all well-formed,
-as are the initializers of <code class="highlight"><c- n>ds1</c-></code> and <code class="highlight"><c- n>ds2</c-></code> (which do).</p>
-   <p>However, the natural and useful <code class="highlight"><c- n>ds3</c-></code> is ill-formed, even though the <code class="highlight"><c- o>&amp;</c-><c- n>mr</c-></code> argument is irrelevant to determining the
-template arguments for <code class="highlight"><c- n>stack</c-></code>! It seems clearly wrong that we give all the right information to unambiguously deduce
+   <p>The initializers of <code class="highlight"><c- n="">s1</c-></code>, <code class="highlight"><c- n="">s2</c-></code>, and <code class="highlight"><c- n="">s3</c-></code> (which do not use CTAD) are all well-formed,
+as are the initializers of <code class="highlight"><c- n="">ds1</c-></code> and <code class="highlight"><c- n="">ds2</c-></code> (which do).</p>
+   <p>However, the natural and useful <code class="highlight"><c- n="">ds3</c-></code> is ill-formed, even though the <code class="highlight"><c- o="">&amp;</c-><c- n="">mr</c-></code> argument is irrelevant to determining the
+template arguments for <code class="highlight"><c- n="">stack</c-></code>! It seems clearly wrong that we give all the right information to unambiguously deduce
 the desired specialization of stack and then reject what would be a perfectly valid constructor invocation for that
 class. The allocator parameter’s type does not <em>contribute</em> to class template argument deduction in these cases;
 it brings no new information, and therefore should be treated no differently than it is in the non-CTAD case.
 Indeed, we believe this is an oversight and should simply be fixed.</p>
-   <h3 class="heading settled" data-level="1.2" id="explanation1"><span class="secno">1.2. </span><span class="content">The explanation</span><a class="self-link" href="#explanation1"></a></h3>
-   <p><code class="highlight"><c- n>stack</c-></code> has one relevant deduction guide.</p>
-<pre class="language-c++ highlight">    <c- n>template</c-><c- o>&lt;</c-><c- n>class</c-> <c- n>Container</c-><c- p>,</c-> <c- n>class</c-> <c- n>Allocator</c-><c- o>></c->
-    <c- n>stack</c-><c- p>(</c-><c- n>Container</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c-> <c- o>-></c-> <c- n>stack</c-><c- o>&lt;</c-><c- kr>typename</c-> <c- n>Container</c-><c- o>::</c-><c- n>value_type</c-><c- p>,</c-> <c- n>Container</c-><c- o>></c-><c- p>;</c->
+   <h3 class="heading settled" data-level="2.2" id="explanation1"><span class="secno">2.2. </span><span class="content">The explanation</span><a class="self-link" href="#explanation1"></a></h3>
+   <p><code class="highlight"><c- n="">stack</c-></code> has one relevant deduction guide.</p>
+<pre class="language-c++ highlight">    <c- n="">template</c-><c- o="">&lt;</c-><c- n="">class</c-> <c- n="">Container</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Allocator</c-><c- o="">&gt;</c->
+    <c- n="">stack</c-><c- p="">(</c-><c- n="">Container</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- p="">)</c-> <c- o="">-&gt;</c-> <c- n="">stack</c-><c- o="">&lt;</c-><c- n="">typename</c-> <c- n="">Container</c-><c- o="">::</c-><c- n="">value_type</c-><c- p="">,</c-> <c- n="">Container</c-><c- o="">&gt;</c-><c- p="">;</c->
 </pre>
    <p>This deduction guide satisfies the following constraints.</p>
    <p>[container.adaptors.general] says: <small></small></p>
    <blockquote><small> A deduction guide for a container adaptor shall not participate in overload resolution if
-any of the following are true: ...<p></p> <ul><li data-md><p><b>It has an <code class="highlight"><c- n>Allocator</c-></code> template parameter and a type that does not qualify as an allocator
-  is deduced for that parameter.</b></p> </li><li data-md><p>It has both <code class="highlight"><c- n>Container</c-></code> and <code class="highlight"><c- n>Allocator</c-></code> template parameters, and <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>Container</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-></code> is <code class="highlight">false</code>.</p> </li></ul> </small></blockquote>
-   <p>To qualify as an allocator, a type <code class="highlight"><c- n>A</c-></code> must have a nested typedef <code class="highlight"><c- n>A</c-><c- o>::</c-><c- n>value_type</c-></code> <small>([container.requirements.general]/17)</small>.
-Since <code class="highlight"><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-><c- o>*</c-></code> has no such nested typedef, <code class="highlight"><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-><c- o>*</c-></code> doesn’t qualify as an allocator.
-However, <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-><c- o>*></c-></code> is <code class="highlight">true</code>.</p>
-   <p>Because the type of <code class="highlight"><c- o>&amp;</c-><c- n>mr</c-></code> doesn’t qualify as an allocator, the deduction guide drops out
+any of the following are true: ...<p></p> <ul><li data-md=""><p><b>It has an <code class="highlight"><c- n="">Allocator</c-></code> template parameter and a type that does not qualify as an allocator
+  is deduced for that parameter.</b></p> </li><li data-md=""><p>It has both <code class="highlight"><c- n="">Container</c-></code> and <code class="highlight"><c- n="">Allocator</c-></code> template parameters, and <code class="highlight"><c- n="">uses_allocator_v</c-><c- o="">&lt;</c-><c- n="">Container</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- o="">&gt;</c-></code> is <code class="highlight">false</code>.</p> </li></ul> </small></blockquote>
+   <p>To qualify as an allocator, a type <code class="highlight"><c- n="">A</c-></code> must have a nested typedef <code class="highlight"><c- n="">A</c-><c- o="">::</c-><c- n="">value_type</c-></code> <small>([container.requirements.general]/17)</small>.
+Since <code class="highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-><c- o="">*</c-></code> has no such nested typedef, <code class="highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-><c- o="">*</c-></code> doesn’t qualify as an allocator.
+However, <code class="highlight"><c- n="">uses_allocator_v</c-><c- o="">&lt;</c-><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-><c- o="">*&gt;</c-></code> is <code class="highlight">true</code>.</p>
+   <p>Because the type of <code class="highlight"><c- o="">&amp;</c-><c- n="">mr</c-></code> doesn’t qualify as an allocator, the deduction guide drops out
 of overload resolution, failing deduction even though it has all the information
-needed to safely deduce the correct template arguments for <code class="highlight"><c- n>stack</c-></code>.</p>
-   <h3 class="heading settled" data-level="1.3" id="solution1"><span class="secno">1.3. </span><span class="content">The solution</span><a class="self-link" href="#solution1"></a></h3>
+needed to safely deduce the correct template arguments for <code class="highlight"><c- n="">stack</c-></code>.</p>
+   <h3 class="heading settled" data-level="2.3" id="solution1"><span class="secno">2.3. </span><span class="content">The solution</span><a class="self-link" href="#solution1"></a></h3>
    <p>To fix all three container adaptors, modify <a href="http://eel.is/c++draft/container.adaptors.general">[container.adaptors.general</a>] as follows:</p>
    <p><small></small></p>
-   <blockquote><small> A deduction guide for a container adaptor shall not participate in overload resolution if any of the following are true:<p></p> <ul><li data-md><p>It has an <code class="highlight"><c- n>InputIterator</c-></code> template parameter and a type that does not qualify as an
- input iterator is deduced for that parameter.</p> </li><li data-md><p>It has a <code class="highlight"><c- n>Compare</c-></code> template parameter and a type that qualifies as an allocator is deduced
- for that parameter.</p> </li><li data-md><p>It has a <code class="highlight"><c- n>Container</c-></code> template parameter and a type that qualifies as an allocator is deduced
- for that parameter.</p> </li><li data-md><del>It has an <code class="highlight"><c- n>Allocator</c-></code> template parameter and a type that does not qualify as an allocator
- is deduced for that parameter.</del> </li><li data-md><p>It has both <code class="highlight"><c- n>Container</c-></code> and <code class="highlight"><c- n>Allocator</c-></code> template parameters, and <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>Container</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-></code> is <code class="highlight">false</code>.</p> </li></ul> </small></blockquote>
-   <p class="note" role="note"><span>Note:</span> The rationale is that if the <code class="highlight"><c- n>Container</c-></code> advertises that it can "use" the supplied allocator,
-we shouldn’t interrogate it any more closely. Trust the <code class="highlight"><c- n>Container</c-></code>'s specialization of <code class="highlight"><c- n>uses_allocator</c-></code>.</p>
-   <p class="note" role="note"><span>Note:</span> No container adaptor deduction guide has an <code class="highlight"><c- n>Allocator</c-></code> template parameter without also having
-a <code class="highlight"><c- n>Container</c-></code> template parameter.</p>
-   <h2 class="heading settled" data-level="2" id="overconst2"><span class="secno">2. </span><span class="content">Stop deducing from allocators that should not participate in deduction</span><a class="self-link" href="#overconst2"></a></h2>
-   <h3 class="heading settled" data-level="2.1" id="problem2"><span class="secno">2.1. </span><span class="content">The problem</span><a class="self-link" href="#problem2"></a></h3>
+   <blockquote><small> A deduction guide for a container adaptor shall not participate in overload resolution if any of the following are true:<p></p> <ul><li data-md=""><p>It has an <code class="highlight"><c- n="">InputIterator</c-></code> template parameter and a type that does not qualify as an
+ input iterator is deduced for that parameter.</p> </li><li data-md=""><p>It has a <code class="highlight"><c- n="">Compare</c-></code> template parameter and a type that qualifies as an allocator is deduced
+ for that parameter.</p> </li><li data-md=""><p>It has a <code class="highlight"><c- n="">Container</c-></code> template parameter and a type that qualifies as an allocator is deduced
+ for that parameter.</p> </li><li data-md=""><p>It has <ins>no Container template parameter, and it has</ins> an <code class="highlight"><c- n="">Allocator</c-></code> template parameter<ins>,</ins> and a type that does not qualify as an allocator
+ is deduced for that parameter.</p> </li><li data-md=""><p>It has both <code class="highlight"><c- n="">Container</c-></code> and <code class="highlight"><c- n="">Allocator</c-></code> template parameters, and <code class="highlight"><c- n="">uses_allocator_v</c-><c- o="">&lt;</c-><c- n="">Container</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- o="">&gt;</c-></code> is <code class="highlight">false</code>.</p> </li></ul> </small></blockquote>
+   <p class="note" role="note"><span>Note:</span> The rationale is that if the <code class="highlight"><c- n="">Container</c-></code> advertises that it can "use" the supplied allocator,
+we shouldn’t interrogate it any more closely. Trust the <code class="highlight"><c- n="">Container</c-></code>'s specialization of <code class="highlight"><c- n="">uses_allocator</c-></code>.</p>
+   <p class="note" role="note"><span>Note:</span> No container adaptor deduction guide has an <code class="highlight"><c- n="">Allocator</c-></code> template parameter without also having
+a <code class="highlight"><c- n="">Container</c-></code> template parameter.</p>
+   <h2 class="heading settled" data-level="3" id="overconst2"><span class="secno">3. </span><span class="content">Stop deducing from allocators that should not participate in deduction</span><a class="self-link" href="#overconst2"></a></h2>
+   <h3 class="heading settled" data-level="3.1" id="problem2"><span class="secno">3.1. </span><span class="content">The problem</span><a class="self-link" href="#problem2"></a></h3>
    <p>Consider the following code:</p>
-<pre class="language-c++ highlight"><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-> <c- n>mr</c-><c- p>;</c->
-<c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-> <c- n>a</c-> <c- o>=</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>;</c->
-<c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-> <c- n>pv</c-><c- p>(</c-><c- n>a</c-><c- p>);</c->
+<pre class="language-c++ highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-> <c- n="">mr</c-><c- p="">;</c->
+<c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">;</c->
+<c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-> <c- n="">pv</c-><c- p="">(</c-><c- n="">a</c-><c- p="">);</c->
 
-<c- k>auto</c-> <c- n>v1</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>v2</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- n>a</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>v3</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- p>,</c-> <c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>>></c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>);</c->
+<c- k="">auto</c-> <c- n="">v1</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">v2</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- n="">a</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">v3</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- p="">,</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;&gt;</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">);</c->
 
-<c- k>auto</c-> <c- n>dv1</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- p>(</c-><c- n>pv</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>dv2</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- n>a</c-><c- p>);</c->
-<c- k>auto</c-> <c- n>dv3</c-> <c- o>=</c-> <c- n>std</c-><c- o>::</c-><c- n>vector</c-><c- p>(</c-><c- n>pv</c-><c- p>,</c-> <c- o>&amp;</c-><c- n>mr</c-><c- p>);</c->
+<c- k="">auto</c-> <c- n="">dv1</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">dv2</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- n="">a</c-><c- p="">);</c->
+<c- k="">auto</c-> <c- n="">dv3</c-> <c- o="">=</c-> <c- n="">std</c-><c- o="">::</c-><c- n="">vector</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">,</c-> <c- o="">&amp;</c-><c- n="">mr</c-><c- p="">);</c->
 </pre>
-   The initializers of <code class="highlight"><c- n>v1</c-></code>, <code class="highlight"><c- n>v2</c-></code>, and <code class="highlight"><c- n>v3</c-></code> (which do not use CTAD) are all well-formed,
-as are the initializers of <code class="highlight"><c- n>dv1</c-></code> and <code class="highlight"><c- n>dv2</c-></code> (which do). 
-   <p>But the initializer of <code class="highlight"><c- n>dv3</c-></code> is ill-formed!</p>
-   <p>Again, we know from the <code class="highlight"><c- n>pv</c-></code> argument that the correct type for the vector is <code class="highlight"><c- k>decltype</c-><c- p>(</c-><c- n>pv</c-><c- p>)</c-></code>, i.e. <code class="highlight"><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>vector</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>. Therefore we
-know what is the possible range of types for the allocator parameter. The allocator parameter’s type does not <em>contribute</em> to class template argument deduction in these cases; it brings no new information, and therefore should be treated no differently
+   The initializers of <code class="highlight"><c- n="">v1</c-></code>, <code class="highlight"><c- n="">v2</c-></code>, and <code class="highlight"><c- n="">v3</c-></code> (which do not use CTAD) are all well-formed,
+as are the initializers of <code class="highlight"><c- n="">dv1</c-></code> and <code class="highlight"><c- n="">dv2</c-></code> (which do). 
+   <p>But the initializer of <code class="highlight"><c- n="">dv3</c-></code> is ill-formed!</p>
+   <p>Again, we know from the <code class="highlight"><c- n="">pv</c-></code> argument that the correct type for the vector is <code class="highlight"><c- k="">decltype</c-><c- p="">(</c-><c- n="">pv</c-><c- p="">)</c-></code>, i.e. <code class="highlight"><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">vector</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>. Therefore we
+know what is the possible range of types for the allocator parameter. The allocator parameter’s type does not <em>contribute</em>
+ to class template argument deduction in these cases; it brings no new 
+information, and therefore should be treated no differently
 than it is in the non-CTAD case.</p>
-   <p>The problem we see with <code class="highlight"><c- n>vector</c-></code> also occurs for all other sequence containers, associative containers, and unordered associative containers.</p>
-   <h3 class="heading settled" data-level="2.2" id="explanation2"><span class="secno">2.2. </span><span class="content">The explanation</span><a class="self-link" href="#explanation2"></a></h3>
-   <p><code class="highlight"><c- n>vector</c-></code> has only one deduction guide, and it’s not relevant to what happens here. Here, we end up
+   <p>The problem we see with <code class="highlight"><c- n="">vector</c-></code> also occurs for all other sequence containers, associative containers, and unordered associative containers.</p>
+   <h3 class="heading settled" data-level="3.2" id="explanation2"><span class="secno">3.2. </span><span class="content">The explanation</span><a class="self-link" href="#explanation2"></a></h3>
+   <p><code class="highlight"><c- n="">vector</c-></code> has only one deduction guide, and it’s not relevant to what happens here. Here, we end up
 looking at the implicit guide generated from the constructor</p>
-<pre class="language-c++ highlight">    <c- n>template</c-><c- o>&lt;</c-><c- n>class</c-> <c- n>T</c-><c- p>,</c-> <c- n>class</c-> <c- n>Allocator</c-><c- o>></c->
-    <c- n>class</c-> <c- n>vector</c-> <c- p>{</c->
-        <c- n>vector</c-><c- p>(</c-><c- k>const</c-> <c- n>vector</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>>&amp;</c-><c- p>,</c-> <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-><c- p>);</c->
-    <c- p>};</c->
+<pre class="language-c++ highlight">    <c- n="">template</c-><c- o="">&lt;</c-><c- n="">class</c-> <c- n="">T</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Allocator</c-><c- o="">&gt;</c->
+    <c- n="">class</c-> <c- n="">vector</c-> <c- p="">{</c->
+        <c- n="">vector</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">vector</c-><c- o="">&lt;</c-><c- n="">T</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+    <c- p="">};</c->
 </pre>
-   <p>From the first parameter, we deduce <code class="highlight"><c- n>T</c-><c- o>=</c-><c- b>int</c-></code> and <code class="highlight"><c- n>Allocator</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>.
-From the second parameter, we deduce <code class="highlight"><c- n>Allocator</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-><c- o>*</c-></code>.
-We’ve deduced conflicting types for <code class="highlight"><c- n>Allocator</c-></code>, so deduction fails.</p>
+   <p>From the first parameter, we deduce <code class="highlight"><c- n="">T</c-><c- o="">=</c-><c- b="">int</c-></code> and <code class="highlight"><c- n="">Allocator</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>.
+From the second parameter, we deduce <code class="highlight"><c- n="">Allocator</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-><c- o="">*</c-></code>.
+We’ve deduced conflicting types for <code class="highlight"><c- n="">Allocator</c-></code>, so deduction fails.</p>
    <p>In this case, the second argument unnecessarily participates in deduction, and again unexpectedly
 prevents natural and useful code from working as desired.</p>
-   <h3 class="heading settled" data-level="2.3" id="solution2"><span class="secno">2.3. </span><span class="content">The solution</span><a class="self-link" href="#solution2"></a></h3>
-   <p>We present two approaches for changing the wording that are equivalent in effect.</p>
-   <h4 class="heading settled" data-level="2.3.1" id="option1"><span class="secno">2.3.1. </span><span class="content">Wording option 1</span><a class="self-link" href="#option1"></a></h4>
+   <h3 class="heading settled" data-level="3.3" id="solution2"><span class="secno">3.3. </span><span class="content">The solution</span><a class="self-link" href="#solution2"></a></h3>
    <p>If we were introducing the containers from scratch today, the natural approach would be for the
-constructors to indicate which arguments should be considered deducible, as is usual for function templates.
-For example, modify <a href="http://eel.is/c++draft/deque.overview"> [deque.overview</a>] as follows:</p>
+constructors to indicate which arguments should be considered deducible, as is usual for function templates.</p>
+   <p>Modify <a href="http://eel.is/c++draft/deque.overview"> [deque.overview</a>] as follows:</p>
    <p><small></small></p>
    <blockquote>
     <p></p>
-    <small> <pre class="highlight"><c- n>deque</c-><c- p>(</c-><c- n>deque</c-><c- o>&amp;&amp;</c-><c- p>);</c->
-<del><c- n>deque</c-><c- p>(</c-><c- k>const</c-> <c- n>deque</c-><c- o>&amp;</c-><c- p>,</c-> <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-><c- p>);</c-></del>
-<ins><c- n>deque</c-><c- p>(</c-><c- k>const</c-> <c- n>deque</c-><c- o>&amp;</c-><c- p>,</c-> <c- k>const</c-> <c- n>type_identity_t</c-><c- o>&lt;</c-><c- n>Allocator</c-><c- o>>&amp;</c-><c- p>);</c-></ins>
-<del><c- n>deque</c-><c- p>(</c-><c- n>deque</c-><c- o>&amp;&amp;</c-><c- p>,</c-> <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-><c- p>);</c-></del>
-<ins><c- n>deque</c-><c- p>(</c-><c- n>deque</c-><c- o>&amp;&amp;</c-><c- p>,</c-> <c- k>const</c-> <c- n>type_identity_t</c-><c- o>&lt;</c-><c- n>Allocator</c-><c- o>>&amp;</c-><c- p>);</c-></ins>
-<c- n>deque</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>());</c->
+    <small> <pre class="highlight"><c- n="">deque</c-><c- p="">(</c-><c- n="">deque</c-><c- o="">&amp;&amp;</c-><c- p="">);</c->
+<del><c- n="">deque</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">deque</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">deque</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">deque</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">deque</c-><c- p="">(</c-><c- n="">deque</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">deque</c-><c- p="">(</c-><c- n="">deque</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">deque</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
 </pre></small>
    </blockquote>
-   <p>(Notice that the constructor <code class="highlight"><c- n>deque</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&amp;</c-><c- n>lt</c-><c- p>;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-><c- p>)</c-></code> is not
-changed, because its <code class="highlight"><c- n>Allocator</c-></code> parameter actually does contribute to deduction: without
-that parameter’s type, we would not know what the <code class="highlight"><c- n>deque</c-></code>'s allocator type should be.)</p>
-   <p>If this is not deemed to cause compatibility issues, we like this approach.</p>
-   <h4 class="heading settled" data-level="2.3.2" id="option2"><span class="secno">2.3.2. </span><span class="content">Wording option 2</span><a class="self-link" href="#option2"></a></h4>
-   <p>First modify <a href="http://eel.is/c++draft/sequence.reqmts#13"> [sequence.reqmts</a>]/13 as follows:</p>
-   <p><small></small></p>
-   <blockquote><small> A deduction guide for a sequence container shall not participate in overload resolution
-if it has an <code class="highlight"><c- n>InputIterator</c-></code> template parameter and a type that does not qualify as an
-input iterator is deduced for that parameter, or if it has an <code class="highlight"><c- n>Allocator</c-></code> template parameter
-and a type that does not qualify as an allocator is deduced for that parameter<ins>,
-or if it has an <code class="highlight"><c- n>Alloc</c-></code> template parameter and <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>X</c-><c- p>,</c-> <c- n>Alloc</c-><c- o>></c-></code> is <code class="highlight">false</code> where <code class="highlight"><c- n>X</c-></code> is the deduced type of the sequence container</ins>.<p></p> </small></blockquote>
-   <p>(We think that change is not strictly necessary, but it clarifies our intent.)</p>
-   <p>Add one new deduction guide for each sequence container. For example, modify <a href="http://eel.is/c++draft/deque.overview"> [deque.overview</a>] as follows:</p>
+   <p>(Notice that the constructor <code class="highlight"><c- n="">deque</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&amp;</c-><c- n="">lt</c-><c- p="">;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">)</c-></code> is not
+changed, because its <code class="highlight"><c- n="">Allocator</c-></code> parameter actually does contribute to deduction: without
+that parameter’s type, we would not know what the <code class="highlight"><c- n="">deque</c-></code>'s allocator type should be.)</p>
+   <p>Modify <a href="http://eel.is/c++draft/forwardlist.overview"> [forwardlist.overview</a>] as follows:</p>
    <p><small></small></p>
    <blockquote>
     <p></p>
-    <small> <pre class="highlight"><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-> <c- o>=</c-> <c- n>allocator</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>>></c->
-    <c- n>deque</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c-> <c- n>Allocator</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>())</c->
-      <c- o>-></c-> <c- n>deque</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<ins><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>T</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Alloc</c-><c- o>></c->
-    <c- n>deque</c-><c- p>(</c-><c- n>deque</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>,</c-> <c- n>Alloc</c-><c- p>)</c->
-      <c- o>-></c-> <c- n>deque</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c-></ins>
+    <small> <pre class="highlight"><c- n="">forward_list</c-><c- p="">(</c-><c- n="">forward_list</c-><c- o="">&amp;&amp;</c-><c- p="">);</c->
+<del><c- n="">forward_list</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">forward_list</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">forward_list</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">forward_list</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">forward_list</c-><c- p="">(</c-><c- n="">forward_list</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">forward_list</c-><c- p="">(</c-><c- n="">forward_list</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">forward_list</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
 </pre></small>
    </blockquote>
-   <p>Then, modify <a href="http://eel.is/c++draft/associative.reqmts#15"> [associative.reqmts</a>]/15 as follows:</p>
-   <p><small></small></p>
-   <blockquote><small> A deduction guide for an associative container shall not participate in overload resolution
-if any of the following are true:<p></p> <ul><li data-md><p>It has an <code class="highlight"><c- n>InputIterator</c-></code> template parameter and a type that does not qualify as an input iterator
-    is deduced for that parameter.</p> </li><li data-md><p>It has an <code class="highlight"><c- n>Allocator</c-></code> template parameter and a type that does not qualify as an allocator
-    is deduced for that parameter.</p> </li><li data-md><p>It has a <code class="highlight"><c- n>Compare</c-></code> template parameter and a type that qualifies as an allocator is
-    deduced for that parameter.</p> </li><li data-md><ins>It has an <code class="highlight"><c- n>Alloc</c-></code> template parameter and <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>X</c-><c- p>,</c-> <c- n>Alloc</c-><c- o>></c-></code> is <code class="highlight">false</code> where <code class="highlight"><c- n>X</c-></code> is the deduced type of the associative container</ins>. </li></ul> </small></blockquote>
-   <p>(We think that change is not strictly necessary, but it clarifies our intent.)</p>
-   <p>Add one new deduction guide for each associative container. For example, modify <a href="http://eel.is/c++draft/set.overview"> [set.overview</a>] as follows:</p>
+   <p>Modify <a href="http://eel.is/c++draft/list.overview"> [list.overview</a>] as follows:</p>
    <p><small></small></p>
    <blockquote>
     <p></p>
-    <small> <pre class="highlight"><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Compare</c-> <c- o>=</c-> <c- n>less</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Allocator</c-> <c- o>=</c-> <c- n>allocator</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>>></c->
-  <c- n>set</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c->
-      <c- n>Compare</c-> <c- o>=</c-> <c- n>Compare</c-><c- p>(),</c-> <c- n>Allocator</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>())</c->
-    <c- o>-></c-> <c- n>set</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c-> <c- n>Compare</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>Key</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Compare</c-> <c- o>=</c-> <c- n>less</c-><c- o>&lt;</c-><c- n>Key</c-><c- o>></c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-> <c- o>=</c-> <c- n>allocator</c-><c- o>&lt;</c-><c- n>Key</c-><c- o>>></c->
-  <c- n>set</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>Key</c-><c- o>></c-><c- p>,</c-> <c- n>Compare</c-> <c- o>=</c-> <c- n>Compare</c-><c- p>(),</c-> <c- n>Allocator</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>())</c->
-    <c- o>-></c-> <c- n>set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>Compare</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>set</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>set</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c->
-           <c- n>less</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>Key</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>set</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>Key</c-><c- o>></c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c-> <c- o>-></c-> <c- n>set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>less</c-><c- o>&lt;</c-><c- n>Key</c-><c- o>></c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<ins><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>Key</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Compare</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Alloc</c-><c- o>></c->
-  <c- n>set</c-><c- p>(</c-><c- n>set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>Compare</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>,</c-> <c- n>Alloc</c-><c- p>)</c-> <c- o>-></c-> <c- n>set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>Compare</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c-></ins>
+    <small> <pre class="highlight"><c- n="">list</c-><c- p="">(</c-><c- n="">list</c-><c- o="">&amp;&amp;</c-><c- p="">);</c->
+<del><c- n="">list</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">list</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">list</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">list</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">list</c-><c- p="">(</c-><c- n="">list</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">list</c-><c- p="">(</c-><c- n="">list</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">list</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
 </pre></small>
    </blockquote>
-   <p>Then, modify <a href="http://eel.is/c++draft/unord.req#18"> [unord.req</a>]/18 as follows:</p>
-   <p><small></small></p>
-   <blockquote><small> A deduction guide for an unordered associative container shall not participate in overload resolution
-if any of the following are true:<p></p> <ul><li data-md><p>It has an <code class="highlight"><c- n>InputIterator</c-></code> template parameter and a type that does not qualify as an input iterator
-    is deduced for that parameter.</p> </li><li data-md><p>It has an <code class="highlight"><c- n>Allocator</c-></code> template parameter and a type that does not qualify as an allocator
-    is deduced for that parameter.</p> </li><li data-md><p>It has a <code class="highlight"><c- n>Hash</c-></code> template parameter and an integral type or a type that qualifies as an allocator
-    is deduced for that parameter.</p> </li><li data-md><p>It has a <code class="highlight"><c- n>Pred</c-></code> template parameter and a type that qualifies as an allocator is
-    deduced for that parameter.</p> </li><li data-md><ins>It has an <code class="highlight"><c- n>Alloc</c-></code> template parameter and <code class="highlight"><c- n>uses_allocator_v</c-><c- o>&lt;</c-><c- n>X</c-><c- p>,</c-> <c- n>Alloc</c-><c- o>></c-></code> is <code class="highlight">false</code> where <code class="highlight"><c- n>X</c-></code> is the deduced type of the associative container</ins>. </li></ul> </small></blockquote>
-   <p>(We think that change is not strictly necessary, but it clarifies our intent.)</p>
-   <p>Add one new deduction guide for each unordered associative container. For example, modify <a href="http://eel.is/c++draft/unord.set.overview"> [unord.set.overview</a>] as follows:</p>
+   <p>Modify <a href="http://eel.is/c++draft/vector.overview"> [vector.overview</a>] as follows:</p>
    <p><small></small></p>
    <blockquote>
     <p></p>
-    <small> <pre class="highlight"><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Hash</c-> <c- o>=</c-> <c- n>hash</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Pred</c-> <c- o>=</c-> <c- n>equal_to</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Allocator</c-> <c- o>=</c-> <c- n>allocator</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-> <c- o>=</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- p>,</c->
-                <c- n>Hash</c-> <c- o>=</c-> <c- n>Hash</c-><c- p>(),</c-> <c- n>Pred</c-> <c- o>=</c-> <c- n>Pred</c-><c- p>(),</c-> <c- n>Allocator</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>())</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c->
-                     <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>T</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Hash</c-> <c- o>=</c-> <c- n>hash</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c->
-         <c- k>class</c-> <c- nc>Pred</c-> <c- o>=</c-> <c- n>equal_to</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-> <c- o>=</c-> <c- n>allocator</c-><c- o>&lt;</c-><c- n>T</c-><c- o>>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-> <c- o>=</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- p>,</c->
-                <c- n>Hash</c-> <c- o>=</c-> <c- n>Hash</c-><c- p>(),</c-> <c- n>Pred</c-> <c- o>=</c-> <c- n>Pred</c-><c- p>(),</c-> <c- n>Allocator</c-> <c- o>=</c-> <c- n>Allocator</c-><c- p>())</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c->
-                     <c- n>hash</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-                     <c- n>equal_to</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-                     <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>InputIterator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Hash</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>InputIterator</c-><c- p>,</c-> <c- n>InputIterator</c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-><c- p>,</c->
-                <c- n>Hash</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>></c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c->
-                     <c- n>equal_to</c-><c- o>&lt;</c-><i><c- n>iter</c-><c- o>-</c-><c- n>value</c-><c- o>-</c-><c- n>type</c-></i><c- o>&lt;</c-><c- n>InputIterator</c-><c- o>>></c-><c- p>,</c->
-                     <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>T</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>hash</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- n>equal_to</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>T</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Hash</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- o>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>initializer_list</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- k>typename</c-> <i><c- n>see</c-> <c- n>below</c-></i><c- o>::</c-><c- n>size_type</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Allocator</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>equal_to</c-><c- o>&lt;</c-><c- n>T</c-><c- o>></c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c->
-
-<ins><c- k>template</c-><c- o>&lt;</c-><c- k>class</c-> <c- nc>T</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Hash</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Pred</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Allocator</c-><c- p>,</c-> <c- k>class</c-> <c- nc>Alloc</c-><c- o>></c->
-  <c- n>unordered_set</c-><c- p>(</c-><c- n>set</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>,</c-> <c- n>Alloc</c-><c- p>)</c->
-    <c- o>-></c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>T</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>></c-><c- p>;</c-></ins>
+    <small> <pre class="highlight"><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">)</c-> <c- k="">noexcept</c-><c- p="">;</c->
+<del><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">vector</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">vector</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
 </pre></small>
    </blockquote>
-   <h3 class="heading settled" data-level="2.4" id="implementation"><span class="secno">2.4. </span><span class="content">Implementation note</span><a class="self-link" href="#implementation"></a></h3>
+   <p>Modify <a href="http://eel.is/c++draft/vector.bool"> [vector.bool</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">)</c-> <c- k="">noexcept</c-><c- p="">;</c->
+<del><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">vector</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">vector</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">vector</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- k="">constexpr</c-> <c- nf="">vector</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/map.overview"> [map.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">map</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">map</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">map</c-><c- p="">(</c-><c- n="">map</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">map</c-><c- p="">(</c-><c- n="">map</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">map</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+  <c- k="">const</c-> <c- n="">Compare</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Compare</c-><c- p="">,</c->
+  <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/multimap.overview"> [multimap.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">multimap</c-><c- p="">(</c-><c- n="">multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">multimap</c-><c- p="">(</c-><c- n="">multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">multimap</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c-> 
+  <c- k="">const</c-> <c- n="">Compare</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Compare</c-><c- p="">,</c->
+  <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/set.overview"> [set.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">set</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">set</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">set</c-><c- p="">(</c-><c- n="">set</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">set</c-><c- p="">(</c-><c- n="">set</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">set</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Compare</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Compare</c-><c- p="">(),</c-> <c- n="">Allocator</c-><c- p="">,</c->
+    <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/multiset.overview"> [multiset.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">multiset</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">multiset</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">multiset</c-><c- p="">(</c-><c- n="">multiset</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">multiset</c-><c- p="">(</c-><c- n="">multiset</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">multiset</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">T</c-><c- o="">&gt;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Compare</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Compare</c-><c- p="">(),</c-> <c- n="">Allocator</c-><c- p="">,</c->
+    <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-> <c- o="">=</c-> <c- n="">Allocator</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/unord.map.overview"> [unord.map.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">unordered_map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_map</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_map</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_map</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">unordered_map</c-><c- p="">(</c-><c- n="">unordered_map</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_map</c-><c- p="">(</c-><c- n="">unordered_map</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">unordered_map</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
+              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/unord.multimap.overview"> [unord.multimap.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
+              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/unord.multimap.overview"> [unord.multimap.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multimap</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">unordered_multimap</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">unordered_multimap</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
+              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/unord.set.overview"> [unord.set.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">unordered_set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_set</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_set</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">unordered_set</c-><c- p="">(</c-><c- n="">unordered_set</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_set</c-><c- p="">(</c-><c- n="">unordered_set</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">unordered_set</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
+              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <p>Modify <a href="http://eel.is/c++draft/unord.multiset.overview"> [unord.multiset.overview</a>] as follows:</p>
+   <p><small></small></p>
+   <blockquote>
+    <p></p>
+    <small> <pre class="highlight"><c- k="">explicit</c-> <c- nf="">unordered_multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+<del><c- n="">unordered_multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multiset</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multiset</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_multiset</c-><c- o="">&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<del><c- n="">unordered_multiset</c-><c- p="">(</c-><c- n="">unordered_multiset</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c-></del>
+<ins><c- n="">unordered_multiset</c-><c- p="">(</c-><c- n="">unordered_multiset</c-><c- o="">&amp;&amp;</c-><c- p="">,</c-> <c- k="">const</c-> <c- n="">type_identity_t</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">);</c-></ins>
+<c- n="">unordered_multiset</c-><c- p="">(</c-><c- n="">initializer_list</c-><c- o="">&lt;</c-><c- n="">value_type</c-><c- o="">&gt;</c-><c- p="">,</c->
+              <c- n="">size_type</c-> <c- n="">n</c-> <c- o="">=</c-> <i><c- n="">see</c-> <c- n="">below</c-></i><c- p="">,</c->
+              <c- k="">const</c-> <c- n="">hasher</c-><c- o="">&amp;</c-> <c- n="">hf</c-> <c- o="">=</c-> <c- n="">hasher</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">key_equal</c-><c- o="">&amp;</c-> <c- n="">eql</c-> <c- o="">=</c-> <c- n="">key_equal</c-><c- p="">(),</c->
+              <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-> <c- n="">a</c-> <c- o="">=</c-> <c- n="">allocator_type</c-><c- p="">());</c->
+</pre></small>
+   </blockquote>
+   <h3 class="heading settled" data-level="3.4" id="implementation"><span class="secno">3.4. </span><span class="content">Implementation note</span><a class="self-link" href="#implementation"></a></h3>
     While implementers may of course implement this proposal exactly as described in the wording options above,
 we wish to point out that a number of library implementations already behave in many cases as we are
 proposing here as shown in the following table and <a href="https://godbolt.org/z/1QepHG">this Godbolt</a>: 
    <p><small></small></p>
    <small> <table class="def"> <tbody><tr><th>Construct</th><th>Well-formed</th><th>SFINAE-friendly<br> ill-formed</th><th>Hard error</th></tr> <tr><td>std::deque(pd, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::forward_list(pfl, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::list(pl, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::vector(pv, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::map(pm, &amp;mr)</td> <td>MSVC</td> <td>libstdc++, libc++</td> <td></td> </tr><tr><td>std::multimap(pmm, &amp;mr)</td> <td>MSVC</td> <td>libstdc++, libc++</td> <td></td> </tr><tr><td>std::multiset(pms, &amp;mr)</td> <td>MSVC</td> <td>libstdc++, libc++</td> <td></td> </tr><tr><td>std::set(ps, &amp;mr)</td> <td>MSVC</td> <td>libstdc++, libc++</td> <td></td> </tr><tr><td>std::unordered_map(pum, &amp;mr)</td> <td>MSVC, libstdc++</td> <td>libc++</td> <td></td> </tr><tr><td>std::unordered_multimap(pumm, &amp;mr)</td> <td>MSVC, libstdc++</td> <td>libc++</td> <td></td> </tr><tr><td>std::unordered_multiset(pums, &amp;mr)</td> <td>MSVC, libstdc++</td> <td>libc++</td> <td></td> </tr><tr><td>std::unordered_set(pus, &amp;mr)</td> <td>MSVC, libstdc++</td> <td>libc++</td> <td></td> </tr><tr></tr> <tr><td>std::priority_queue(ppq, &amp;mr)</td> <td>MSVC, libstdc++, libc++</td> <td></td> <td></td> </tr><tr><td>std::queue(pq, &amp;mr)</td> <td>MSVC, libstdc++, libc++</td> <td></td> <td></td> </tr><tr><td>std::stack(ps, &amp;mr)</td> <td>MSVC, libstdc++, libc++</td> <td></td> <td></td> </tr><tr></tr> <tr><td>std::priority_queue(pv, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::queue(pd, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr><tr><td>std::stack(pv, &amp;mr)</td> <td></td> <td>MSVC, libstdc++, libc++</td> <td></td> </tr></tbody></table> </small> 
    <p>The following analysis explains why MSVC, in effect, already implements
-the approach described in <a href="#option1">wording option 1</a> above.
+the approach described in <a href="#solution2">§ 3.3 The solution</a> above.
 Consider the implicit guide generated from the constructor</p>
-<pre class="language-c++ highlight">    <c- n>template</c-><c- o>&lt;</c-><c- n>class</c-> <c- n>Key</c-><c- p>,</c-> <c- n>class</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>class</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>class</c-> <c- n>Allocator</c-><c- o>></c->
-    <c- n>class</c-> <c- n>unordered_set</c-> <c- p>{</c->
-        <c- n>unordered_set</c-><c- p>(</c-><c- k>const</c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>>&amp;</c-><c- p>,</c->
-                      <c- k>const</c-> <c- n>Allocator</c-><c- o>&amp;</c-><c- p>);</c->
-    <c- p>};</c->
+<pre class="language-c++ highlight">    <c- n="">template</c-><c- o="">&lt;</c-><c- n="">class</c-> <c- n="">Key</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Hash</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Pred</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Allocator</c-><c- o="">&gt;</c->
+    <c- n="">class</c-> <c- n="">unordered_set</c-> <c- p="">{</c->
+        <c- n="">unordered_set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_set</c-><c- o="">&lt;</c-><c- n="">Key</c-><c- p="">,</c-> <c- n="">Hash</c-><c- p="">,</c-> <c- n="">Pred</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">,</c->
+                      <c- k="">const</c-> <c- n="">Allocator</c-><c- o="">&amp;</c-><c- p="">);</c->
+    <c- p="">};</c->
 </pre>
-   <p>From the first parameter, we deduce <code class="highlight"><c- n>Key</c-><c- o>=</c-><c- b>int</c-></code>, <code class="highlight"><c- n>Hash</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>hash</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>, <code class="highlight"><c- n>Pred</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>equal_to</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>,
-and <code class="highlight"><c- n>Allocator</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>.
-From the second parameter, we should deduce <code class="highlight"><c- n>Allocator</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>monotonic_buffer_resource</c-><c- o>*</c-></code>.
-We’ve deduced conflicting types for <code class="highlight"><c- n>Allocator</c-></code>, so deduction fails.</p>
-   <p>However, in practice, both MSVC and libstdc++ launder the <code class="highlight"><c- n>Allocator</c-></code> type through a typedef
+   <p>From the first parameter, we deduce <code class="highlight"><c- n="">Key</c-><c- o="">=</c-><c- b="">int</c-></code>, <code class="highlight"><c- n="">Hash</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">hash</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>, <code class="highlight"><c- n="">Pred</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">equal_to</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>,
+and <code class="highlight"><c- n="">Allocator</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>.
+From the second parameter, we should deduce <code class="highlight"><c- n="">Allocator</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">monotonic_buffer_resource</c-><c- o="">*</c-></code>.
+We’ve deduced conflicting types for <code class="highlight"><c- n="">Allocator</c-></code>, so deduction fails.</p>
+   <p>However, in practice, both MSVC and libstdc++ launder the <code class="highlight"><c- n="">Allocator</c-></code> type through a typedef
 that is opaque to deduction, so
 that the constructor seen by the compiler in practice is equivalent to</p>
-<pre class="language-c++ highlight">    <c- n>template</c-><c- o>&lt;</c-><c- n>class</c-> <c- n>Key</c-><c- p>,</c-> <c- n>class</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>class</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>class</c-> <c- n>Allocator</c-><c- o>></c->
-    <c- n>class</c-> <c- n>unordered_set</c-> <c- p>{</c->
-        <c- n>using</c-> <c- n>allocator_type</c-> <c- o>=</c-> <c- kr>typename</c-> <c- n>type_identity</c-><c- o>&lt;</c-><c- n>Allocator</c-><c- o>>::</c-><c- n>type</c-><c- p>;</c->
-        <c- n>unordered_set</c-><c- p>(</c-><c- k>const</c-> <c- n>unordered_set</c-><c- o>&lt;</c-><c- n>Key</c-><c- p>,</c-> <c- n>Hash</c-><c- p>,</c-> <c- n>Pred</c-><c- p>,</c-> <c- n>Allocator</c-><c- o>>&amp;</c-><c- p>,</c->
-                      <c- k>const</c-> <c- n>allocator_type</c-><c- o>&amp;</c-><c- p>);</c->
-    <c- p>};</c->
+<pre class="language-c++ highlight">    <c- n="">template</c-><c- o="">&lt;</c-><c- n="">class</c-> <c- n="">Key</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Hash</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Pred</c-><c- p="">,</c-> <c- n="">class</c-> <c- n="">Allocator</c-><c- o="">&gt;</c->
+    <c- n="">class</c-> <c- n="">unordered_set</c-> <c- p="">{</c->
+        <c- n="">using</c-> <c- n="">allocator_type</c-> <c- o="">=</c-> <c- n="">typename</c-> <c- n="">type_identity</c-><c- o="">&lt;</c-><c- n="">Allocator</c-><c- o="">&gt;::</c-><c- n="">type</c-><c- p="">;</c->
+        <c- n="">unordered_set</c-><c- p="">(</c-><c- k="">const</c-> <c- n="">unordered_set</c-><c- o="">&lt;</c-><c- n="">Key</c-><c- p="">,</c-> <c- n="">Hash</c-><c- p="">,</c-> <c- n="">Pred</c-><c- p="">,</c-> <c- n="">Allocator</c-><c- o="">&gt;&amp;</c-><c- p="">,</c->
+                      <c- k="">const</c-> <c- n="">allocator_type</c-><c- o="">&amp;</c-><c- p="">);</c->
+    <c- p="">};</c->
 </pre>
-   <p>From the first parameter, we deduce <code class="highlight"><c- n>Key</c-><c- o>=</c-><c- b>int</c-></code>, <code class="highlight"><c- n>Hash</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>hash</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>, <code class="highlight"><c- n>Pred</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>equal_to</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>,
-and <code class="highlight"><c- n>Allocator</c-><c- o>=</c-><c- n>std</c-><c- o>::</c-><c- n>pmr</c-><c- o>::</c-><c- n>polymorphic_allocator</c-><c- o>&lt;</c-><c- b>int</c-><c- o>></c-></code>.
+   <p>From the first parameter, we deduce <code class="highlight"><c- n="">Key</c-><c- o="">=</c-><c- b="">int</c-></code>, <code class="highlight"><c- n="">Hash</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">hash</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>, <code class="highlight"><c- n="">Pred</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">equal_to</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>,
+and <code class="highlight"><c- n="">Allocator</c-><c- o="">=</c-><c- n="">std</c-><c- o="">::</c-><c- n="">pmr</c-><c- o="">::</c-><c- n="">polymorphic_allocator</c-><c- o="">&lt;</c-><c- b="">int</c-><c- o="">&gt;</c-></code>.
 From the second parameter, we don’t deduce anything.
 In practice, therefore, deduction succeeds.</p>
    <p>Implementers who have taken the above approach can use that to simplify their
@@ -1882,4 +2580,4 @@ implementation of this proposal, as an alternative to directly implementing the 
   }
 
 })();
-</script>
+</script></body></html>


### PR DESCRIPTION
Modifications requested in 2020-02-12 LWG telecon communicated by Arthur O'Dwyer as follows

> Notes from today's Zoom telecon:
>
> LWG's suggestion re LWG3506 is that instead of removing this bullet point completely... 
> * It has an Allocator template parameter and a type that does not qualify as an allocator is deduced for that parameter.
...we just replace it with
> * It has no Container template parameter, and it has an Allocator template parameter, and a type that does not qualify as an allocator is deduced for that Allocator parameter.
>
> (The set of constructor signatures with Allocator-and-no-Container is empty at the moment, but LWG3506 will make it non-empty.)
>
> LWG likes Wording Option 1 better than Wording Option 2. We should write out the entire diff for that proposal, and remove Wording Option 2.
> No special notes or anything are needed to explain why type_identity_t shows up here.
> Arguably, precedent for unexplained usage of type_identity_t is given by one example in http://eel.is/c++draft/string.view#comparison-example-1
